### PR TITLE
Made clients take a `session` arg, changed cookies to be set on request instead of in the `ClientSession`s.

### DIFF
--- a/genshin/client.py
+++ b/genshin/client.py
@@ -99,7 +99,6 @@ class GenshinClient:
         :param authkey: The authkey used for paginators
         :param lang: The default language
         :param debug: Whether debug logs should be shown in stdout
-        :param session: A custom session to be used for requests instead of the default
         """
         self.cookies = cookies or {}
         self.authkey = authkey


### PR DESCRIPTION
I have done exactly as the title said. By moving cookies from `ClientSession`s directly to instance vars, the properties for them could be removed. Furthermore, changed a type-hint in `set_cookies` as it didn't make sense to me (I presume one enters either a str (file path) or a list of dicts; there probably shouldn't be a possibility for a list of strs). Similarly, changed the implementation of MultiCookieClient to store a list of cookies for a single ClientSession instead of a list of ClientSessions each with its own cookies.

I tested everything with pytest - for which I had to change some UIDs and usernames to my own, as I assume the tests are tailor-made to your own account. I managed to get just about everything to pass, except:

1. CN hoyolab tests, as I don't have access to any CN accounts,
2. the fourth hoyolab test (skipped), 
3. the sixth record test, for which I apparently haven't set data to public.

Not that this really proves anything, but nonetheless:
![image](https://user-images.githubusercontent.com/55550164/145122772-a4db5259-b580-4ea9-a6a7-b87403ae0f2e.png)

I also made sure to format with black with line length set to 100.

Hope I didn't do too bad for a first pull request. If there's anything I need to follow up on, please let me know ^^

EDIT:
Oh right, just FYI, I installed everything from requirements.txt, so the current aiohttp versions are sufficient for these changes. I should probably also mention that this was done with my own bot in mind, as discussed on discord. I just thought to check in with you if you wanted to use it here too.