### PR TITLE
Fix install command

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -47,7 +47,7 @@ As long as you are logged into your account on one of your browsers, you can get
 #### Installation
 
 ```console
-pip install genshin[cookies, rsa]
+pip install genshin[cookies,rsa]
 ```
 
 #### Example


### PR DESCRIPTION
The original command as is would display `ERROR: Invalid requirement: 'genshin[cookies,'`.
(I don't do a lot of PR, so please feel free to correct me if I'm wrong...)