### PR TITLE
Add clearer error for an empty string in cookie value when accessing `user_id`

### DIFF
--- a/genshin/client/manager/managers.py
+++ b/genshin/client/manager/managers.py
@@ -249,6 +249,9 @@ class CookieManager(BaseCookieManager):
         """
         for name, value in self.cookies.items():
             if name in ("ltuid", "account_id", "ltuid_v2", "account_id_v2"):
+                if not value:
+                    raise ValueError(f"{name} can not be an empty string.")
+
                 return int(value)
 
         return None


### PR DESCRIPTION
Resolves #154 