### PR TITLE
Make HSR Pure Fiction floor buff optional

### DIFF
--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -1,6 +1,6 @@
 """Starrail chronicle challenge."""
 
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
     import pydantic.v1 as pydantic
@@ -71,7 +71,7 @@ class FictionBuff(APIModel):
 class FictionFloorNode(FloorNode):
     """Node for a Pure Fiction floor."""
 
-    buff: FictionBuff
+    buff: Optional[FictionBuff]
     score: int
 
 


### PR DESCRIPTION
HoYoverse for some reason does not prune the earlier Pure Fiction stages from their API response if your account did a Quick Clear (this is also the same for the MoC).

Unlike MoC, this can throw pydantic errors as the returned Pure Fiction buff values for the quick-cleared floors are null. Making the buff an `Optional` solves the pydantic errors.