### PR TITLE
Add Miyoushe login methods

### DIFF
--- a/genshin/client/components/geetest/client.py
+++ b/genshin/client/components/geetest/client.py
@@ -239,6 +239,81 @@ class GeetestClient(base.BaseClient):
 
         return None
 
+    async def _send_mobile_otp(
+        self,
+        mobile: str,
+        *,
+        geetest: typing.Optional[typing.Dict[str, typing.Any]] = None,
+    ) -> typing.Dict[str, typing.Any] | None:
+        """Attempt to send OTP to the provided mobile number.
+
+        May return aigis headers if captcha is triggered, None otherwise.
+        """
+        headers = {
+            **geetest_utility.CN_LOGIN_HEADERS,
+            "ds": ds_utility.generate_dynamic_secret(constants.DS_SALT["cn_signin"]),
+        }
+        if geetest:
+            mmt_data = geetest["data"]
+            session_id = geetest["session_id"]
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
+
+        payload = {
+            "mobile": geetest_utility.encrypt_geetest_credentials(mobile, self._region),
+            "area_code": geetest_utility.encrypt_geetest_credentials("+86", self._region),
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                routes.MOBILE_OTP_URL.get_url(),
+                json=payload,
+                headers=headers,
+            ) as r:
+                data = await r.json()
+
+        if data["retcode"] == -3101:
+            # Captcha triggered
+            aigis = json.loads(r.headers["x-rpc-aigis"])
+            aigis["data"] = json.loads(aigis["data"])
+            return aigis
+
+        if not data["data"]:
+            errors.raise_for_retcode(data)
+
+        return None
+
+    async def _login_with_mobile_otp(self, mobile: str, otp: str) -> typing.Dict[str, typing.Any]:
+        """Login with OTP and mobile number.
+
+        Returns cookies if OTP matches the one sent, raises an error otherwise.
+        """
+        headers = {
+            **geetest_utility.CN_LOGIN_HEADERS,
+            "ds": ds_utility.generate_dynamic_secret(constants.DS_SALT["cn_signin"]),
+        }
+
+        payload = {
+            "mobile": geetest_utility.encrypt_geetest_credentials(mobile, self._region),
+            "area_code": geetest_utility.encrypt_geetest_credentials("+86", self._region),
+            "captcha": otp,
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                routes.MOBILE_LOGIN_URL.get_url(),
+                json=payload,
+                headers=headers,
+            ) as r:
+                data = await r.json()
+
+        if not data["data"]:
+            errors.raise_for_retcode(data)
+
+        cookies = {cookie.key: cookie.value for cookie in r.cookies.values()}
+        self.set_cookies(cookies)
+
+        return cookies
+
     async def login_with_password(
         self,
         account: str,
@@ -286,8 +361,7 @@ class GeetestClient(base.BaseClient):
     ) -> typing.Dict[str, str]:
         """Login with a password via Miyoushe loginByPassword endpoint.
 
-        Note that this will start a webserver if captcha is
-        triggered and `geetest_solver` is not passed.
+        Note that this will start a webserver if captcha is triggered and `geetest_solver` is not passed.
         """
         result = await self._cn_login_by_password(account, password)
 
@@ -301,6 +375,45 @@ class GeetestClient(base.BaseClient):
             geetest = await server.solve_geetest(result, port=port)
 
         return await self._cn_login_by_password(account, password, geetest=geetest)
+
+    async def check_mobile_number_validity(self, mobile: str) -> bool:
+        """Check if a mobile number is valid (it's registered on Miyoushe).
+
+        Returns True if the mobile number is valid, False otherwise.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                routes.CHECK_MOBILE_VALIDITY_URL.get_url(),
+                params={"mobile": mobile},
+            ) as r:
+                data = await r.json()
+
+        return data["data"]["status"] != data["data"]["is_registable"]
+
+    async def login_with_mobile_number(
+        self,
+        mobile: str,
+    ) -> typing.Dict[str, str]:
+        """Login with mobile number, returns cookies.
+
+        Only works for Chinese region (Miyoushe) users, do not include area code (+86) in the mobile number.
+        Steps:
+        1. Sends OTP to the provided mobile number.
+        1-1. If captcha is triggered, prompts the user to solve it.
+        2. Lets user enter the OTP.
+        3. Logs in with the OTP.
+        4. Returns cookies.
+        """
+        result = await self._send_mobile_otp(mobile)
+
+        if result is not None and "session_id" in result:
+            # Captcha triggered
+            geetest = await server.solve_geetest(result)
+            await self._send_mobile_otp(mobile, geetest=geetest)
+
+        otp = await server.enter_otp()
+        cookies = await self._login_with_mobile_otp(mobile, otp)
+        return cookies
 
     async def login_with_app_password(
         self,

--- a/genshin/client/components/geetest/client.py
+++ b/genshin/client/components/geetest/client.py
@@ -36,17 +36,11 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
-                session_id, mmt_data
-            )
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(
-                account, self._region
-            ),
-            "password": geetest_utility.encrypt_geetest_credentials(
-                password, self._region
-            ),
+            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
+            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
             "token_type": tokenType,
         }
 
@@ -94,17 +88,11 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
-                session_id, mmt_data
-            )
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(
-                account, self._region
-            ),
-            "password": geetest_utility.encrypt_geetest_credentials(
-                password, self._region
-            ),
+            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
+            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
         }
 
         async with aiohttp.ClientSession() as session:
@@ -148,21 +136,15 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
-                session_id, mmt_data
-            )
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
 
         if ticket:
             ticket["verify_str"] = json.dumps(ticket["verify_str"])
             headers["x-rpc-verify"] = json.dumps(ticket)
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(
-                account, self._region
-            ),
-            "password": geetest_utility.encrypt_geetest_credentials(
-                password, self._region
-            ),
+            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
+            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
         }
 
         async with aiohttp.ClientSession() as session:
@@ -213,9 +195,7 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
-                session_id, mmt_data
-            )
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -239,9 +219,7 @@ class GeetestClient(base.BaseClient):
 
         return None
 
-    async def _verify_email(
-        self, code: str, ticket: typing.Dict[str, typing.Any]
-    ) -> None:
+    async def _verify_email(self, code: str, ticket: typing.Dict[str, typing.Any]) -> None:
         """Verify email."""
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -291,9 +269,7 @@ class GeetestClient(base.BaseClient):
         else:
             geetest = await server.solve_geetest(result, port=port)
 
-        return await self._web_login(
-            account, password, tokenType=tokenType, geetest=geetest
-        )
+        return await self._web_login(account, password, tokenType=tokenType, geetest=geetest)
 
     async def cn_login_by_password(
         self,

--- a/genshin/client/components/geetest/client.py
+++ b/genshin/client/components/geetest/client.py
@@ -2,7 +2,6 @@
 
 import json
 import typing
-from http.cookies import SimpleCookie
 
 import aiohttp
 import aiohttp.web
@@ -37,11 +36,17 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
+                session_id, mmt_data
+            )
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
-            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
+            "account": geetest_utility.encrypt_geetest_credentials(
+                account, self._region
+            ),
+            "password": geetest_utility.encrypt_geetest_credentials(
+                password, self._region
+            ),
             "token_type": tokenType,
         }
 
@@ -89,11 +94,17 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
+                session_id, mmt_data
+            )
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
-            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
+            "account": geetest_utility.encrypt_geetest_credentials(
+                account, self._region
+            ),
+            "password": geetest_utility.encrypt_geetest_credentials(
+                password, self._region
+            ),
         }
 
         async with aiohttp.ClientSession() as session:
@@ -113,13 +124,7 @@ class GeetestClient(base.BaseClient):
         if not data["data"]:
             errors.raise_for_retcode(data)
 
-        # Parse cookies from headers
-        cookies: dict[str, str] = {}
-        for data in r.headers.items():
-            if data[0] == "Set-Cookie":
-                cookie_parser = SimpleCookie()
-                cookie_parser.load(data[1])
-                cookies.update({key: morsel.value for key, morsel in cookie_parser.items()})
+        cookies = {cookie.key: cookie.value for cookie in r.cookies.values()}
 
         self.set_cookies(cookies)
         return cookies
@@ -143,15 +148,21 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
+                session_id, mmt_data
+            )
 
         if ticket:
             ticket["verify_str"] = json.dumps(ticket["verify_str"])
             headers["x-rpc-verify"] = json.dumps(ticket)
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
-            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
+            "account": geetest_utility.encrypt_geetest_credentials(
+                account, self._region
+            ),
+            "password": geetest_utility.encrypt_geetest_credentials(
+                password, self._region
+            ),
         }
 
         async with aiohttp.ClientSession() as session:
@@ -202,7 +213,9 @@ class GeetestClient(base.BaseClient):
         if geetest:
             mmt_data = geetest["data"]
             session_id = geetest["session_id"]
-            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(
+                session_id, mmt_data
+            )
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -226,7 +239,9 @@ class GeetestClient(base.BaseClient):
 
         return None
 
-    async def _verify_email(self, code: str, ticket: typing.Dict[str, typing.Any]) -> None:
+    async def _verify_email(
+        self, code: str, ticket: typing.Dict[str, typing.Any]
+    ) -> None:
         """Verify email."""
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -276,7 +291,9 @@ class GeetestClient(base.BaseClient):
         else:
             geetest = await server.solve_geetest(result, port=port)
 
-        return await self._web_login(account, password, tokenType=tokenType, geetest=geetest)
+        return await self._web_login(
+            account, password, tokenType=tokenType, geetest=geetest
+        )
 
     async def cn_login_by_password(
         self,

--- a/genshin/client/components/geetest/client.py
+++ b/genshin/client/components/geetest/client.py
@@ -2,6 +2,7 @@
 
 import json
 import typing
+from http.cookies import SimpleCookie
 
 import aiohttp
 import aiohttp.web
@@ -39,8 +40,8 @@ class GeetestClient(base.BaseClient):
             headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(account),
-            "password": geetest_utility.encrypt_geetest_credentials(password),
+            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
+            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
             "token_type": tokenType,
         }
 
@@ -69,6 +70,60 @@ class GeetestClient(base.BaseClient):
 
         return cookies
 
+    async def _cn_login_by_password(
+        self,
+        account: str,
+        password: str,
+        *,
+        geetest: typing.Optional[typing.Dict[str, typing.Any]] = None,
+    ) -> typing.Dict[str, typing.Any]:
+        """
+        Login with account and password using Miyoushe loginByPassword endpoint.
+
+        Returns data from aigis header or cookies.
+        """
+        headers = {
+            **geetest_utility.CN_LOGIN_HEADERS,
+            "ds": ds_utility.generate_dynamic_secret(constants.DS_SALT["cn_signin"]),
+        }
+        if geetest:
+            mmt_data = geetest["data"]
+            session_id = geetest["session_id"]
+            headers["x-rpc-aigis"] = geetest_utility.get_aigis_header(session_id, mmt_data)
+
+        payload = {
+            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
+            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                routes.CN_LOGIN_URL.get_url(),
+                json=payload,
+                headers=headers,
+            ) as r:
+                data = await r.json()
+
+        if data["retcode"] == -3102:
+            # Captcha triggered
+            aigis = json.loads(r.headers["x-rpc-aigis"])
+            aigis["data"] = json.loads(aigis["data"])
+            return aigis
+
+        if not data["data"]:
+            errors.raise_for_retcode(data)
+
+        # Parse cookies from headers
+        cookies: dict[str, str] = {}
+        for data in r.headers.items():
+            if data[0] == "Set-Cookie":
+                cookie_parser = SimpleCookie()
+                cookie_parser.load(data[1])
+                cookies.update({key: morsel.value for key, morsel in cookie_parser.items()})
+
+        self.set_cookies(cookies)
+        return cookies
+
     async def _app_login(
         self,
         account: str,
@@ -95,8 +150,8 @@ class GeetestClient(base.BaseClient):
             headers["x-rpc-verify"] = json.dumps(ticket)
 
         payload = {
-            "account": geetest_utility.encrypt_geetest_credentials(account),
-            "password": geetest_utility.encrypt_geetest_credentials(password),
+            "account": geetest_utility.encrypt_geetest_credentials(account, self._region),
+            "password": geetest_utility.encrypt_geetest_credentials(password, self._region),
         }
 
         async with aiohttp.ClientSession() as session:
@@ -199,7 +254,10 @@ class GeetestClient(base.BaseClient):
         port: int = 5000,
         tokenType: typing.Optional[int] = 6,
         geetest_solver: typing.Optional[
-            typing.Callable[[typing.Dict[str, typing.Any]], typing.Awaitable[typing.Dict[str, typing.Any]]]
+            typing.Callable[
+                [typing.Dict[str, typing.Any]],
+                typing.Awaitable[typing.Dict[str, typing.Any]],
+            ]
         ] = None,
     ) -> typing.Dict[str, str]:
         """Login with a password via web endpoint.
@@ -220,6 +278,37 @@ class GeetestClient(base.BaseClient):
 
         return await self._web_login(account, password, tokenType=tokenType, geetest=geetest)
 
+    async def cn_login_by_password(
+        self,
+        account: str,
+        password: str,
+        *,
+        port: int = 5000,
+        geetest_solver: typing.Optional[
+            typing.Callable[
+                [typing.Dict[str, typing.Any]],
+                typing.Awaitable[typing.Dict[str, typing.Any]],
+            ]
+        ] = None,
+    ) -> typing.Dict[str, str]:
+        """Login with a password via Miyoushe loginByPassword endpoint.
+
+        Note that this will start a webserver if captcha is
+        triggered and `geetest_solver` is not passed.
+        """
+        result = await self._cn_login_by_password(account, password)
+
+        if "session_id" not in result:
+            # Captcha not triggered
+            return result
+
+        if geetest_solver:
+            geetest = await geetest_solver(result)
+        else:
+            geetest = await server.solve_geetest(result, port=port)
+
+        return await self._cn_login_by_password(account, password, geetest=geetest)
+
     async def login_with_app_password(
         self,
         account: str,
@@ -227,7 +316,10 @@ class GeetestClient(base.BaseClient):
         *,
         port: int = 5000,
         geetest_solver: typing.Optional[
-            typing.Callable[[typing.Dict[str, typing.Any]], typing.Awaitable[typing.Dict[str, typing.Any]]]
+            typing.Callable[
+                [typing.Dict[str, typing.Any]],
+                typing.Awaitable[typing.Dict[str, typing.Any]],
+            ]
         ] = None,
     ) -> typing.Dict[str, str]:
         """Login with a password via HoYoLab app endpoint.

--- a/genshin/client/components/geetest/client.py
+++ b/genshin/client/components/geetest/client.py
@@ -97,7 +97,7 @@ class GeetestClient(base.BaseClient):
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                routes.CN_LOGIN_URL.get_url(),
+                routes.CN_WEB_LOGIN_URL.get_url(),
                 json=payload,
                 headers=headers,
             ) as r:

--- a/genshin/client/components/geetest/server.py
+++ b/genshin/client/components/geetest/server.py
@@ -14,7 +14,7 @@ from . import client
 __all__ = ["get_page", "launch_webapp", "solve_geetest", "verify_email"]
 
 
-def get_page(page: typing.Literal["captcha", "verify-email"]) -> str:
+def get_page(page: typing.Literal["captcha", "verify-email", "enter-otp"]) -> str:
     """Get the HTML page."""
     return (
         """
@@ -84,7 +84,7 @@ GT_URL = "https://raw.githubusercontent.com/GeeTeam/gt3-node-sdk/master/demo/sta
 
 
 async def launch_webapp(
-    page: typing.Literal["captcha", "verify-email"],
+    page: typing.Literal["captcha", "verify-email", "enter-otp"],
     *,
     port: int = 5000,
     mmt: typing.Optional[typing.Dict[str, typing.Any]] = None,
@@ -100,6 +100,10 @@ async def launch_webapp(
     @routes.get("/verify-email")
     async def verify_email(request: web.Request) -> web.StreamResponse:
         return web.Response(body=get_page("verify-email"), content_type="text/html")
+
+    @routes.get("/enter-otp")
+    async def enter_otp(request: web.Request) -> web.StreamResponse:
+        return web.Response(body=get_page("enter-otp"), content_type="text/html")
 
     @routes.get("/gt.js")
     async def gt(request: web.Request) -> web.StreamResponse:
@@ -162,3 +166,11 @@ async def verify_email(
     code = data["code"]
 
     return await client._verify_email(code, ticket)
+
+
+async def enter_otp(port: int = 5000) -> str:
+    """Lets user enter the OTP."""
+    # The enter-otp page is the same as verify-email page.
+    data = await launch_webapp("enter-otp", port=port)
+    code = data["code"]
+    return code

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -13,6 +13,7 @@ __all__ = [
     "BBS_REFERER_URL",
     "BBS_URL",
     "CALCULATOR_URL",
+    "CN_LOGIN_URL",
     "COMMUNITY_URL",
     "COOKIE_V2_REFRESH_URL",
     "DETAIL_LEDGER_URL",
@@ -217,6 +218,7 @@ COOKIE_V2_REFRESH_URL = Route("https://sg-public-api.hoyoverse.com/account/ma-pa
 
 WEB_LOGIN_URL = Route("https://sg-public-api.hoyolab.com/account/ma-passport/api/webLoginByPassword")
 APP_LOGIN_URL = Route("https://sg-public-api.hoyoverse.com/account/ma-passport/api/appLoginByPassword")
+CN_LOGIN_URL = Route("https://passport-api.miyoushe.com/account/ma-cn-passport/web/loginByPassword")
 
 SEND_VERIFICATION_CODE_URL = Route(
     "https://sg-public-api.hoyoverse.com/account/ma-verifier/api/createEmailCaptchaByActionTicket"

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -224,3 +224,7 @@ SEND_VERIFICATION_CODE_URL = Route(
     "https://sg-public-api.hoyoverse.com/account/ma-verifier/api/createEmailCaptchaByActionTicket"
 )
 VERIFY_EMAIL_URL = Route("https://sg-public-api.hoyoverse.com/account/ma-verifier/api/verifyActionTicketPartly")
+
+CHECK_MOBILE_VALIDITY_URL = Route("https://webapi.account.mihoyo.com/Api/is_mobile_registrable")
+MOBILE_OTP_URL = Route("https://passport-api.miyoushe.com/account/ma-cn-verifier/verifier/createLoginCaptcha")
+MOBILE_LOGIN_URL = Route("https://passport-api.miyoushe.com/account/ma-cn-passport/web/loginByMobileCaptcha")

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -13,7 +13,7 @@ __all__ = [
     "BBS_REFERER_URL",
     "BBS_URL",
     "CALCULATOR_URL",
-    "CN_LOGIN_URL",
+    "CN_WEB_LOGIN_URL",
     "COMMUNITY_URL",
     "COOKIE_V2_REFRESH_URL",
     "DETAIL_LEDGER_URL",
@@ -218,7 +218,7 @@ COOKIE_V2_REFRESH_URL = Route("https://sg-public-api.hoyoverse.com/account/ma-pa
 
 WEB_LOGIN_URL = Route("https://sg-public-api.hoyolab.com/account/ma-passport/api/webLoginByPassword")
 APP_LOGIN_URL = Route("https://sg-public-api.hoyoverse.com/account/ma-passport/api/appLoginByPassword")
-CN_LOGIN_URL = Route("https://passport-api.miyoushe.com/account/ma-cn-passport/web/loginByPassword")
+CN_WEB_LOGIN_URL = Route("https://passport-api.miyoushe.com/account/ma-cn-passport/web/loginByPassword")
 
 SEND_VERIFICATION_CODE_URL = Route(
     "https://sg-public-api.hoyoverse.com/account/ma-verifier/api/createEmailCaptchaByActionTicket"

--- a/genshin/errors.py
+++ b/genshin/errors.py
@@ -31,7 +31,11 @@ class GenshinException(Exception):
     original: str = ""
     msg: str = ""
 
-    def __init__(self, response: typing.Mapping[str, typing.Any] = {}, msg: typing.Optional[str] = None) -> None:
+    def __init__(
+        self,
+        response: typing.Mapping[str, typing.Any] = {},
+        msg: typing.Optional[str] = None,
+    ) -> None:
         self.retcode = response.get("retcode", self.retcode)
         self.original = response.get("message", "")
         self.msg = msg or self.msg or self.original
@@ -176,6 +180,12 @@ class AccountHasLocked(GenshinException):
     msg = "Account has been locked because exceeded password limit. Please wait 20 minute and try again"
 
 
+class WrongOTP(GenshinException):
+    """Wrong OTP code."""
+
+    msg = "The provided OTP code is wrong."
+
+
 _TGE = typing.Type[GenshinException]
 _errors: typing.Dict[int, typing.Union[_TGE, str, typing.Tuple[_TGE, typing.Optional[str]]]] = {
     # misc hoyolab
@@ -189,7 +199,10 @@ _errors: typing.Dict[int, typing.Union[_TGE, str, typing.Tuple[_TGE, typing.Opti
     # database game record
     10101: TooManyRequests,
     10102: DataNotPublic,
-    10103: (InvalidCookies, "Cookies are valid but do not have a hoyolab account bound to them."),
+    10103: (
+        InvalidCookies,
+        "Cookies are valid but do not have a hoyolab account bound to them.",
+    ),
     10104: "Cannot view real-time notes of other users.",
     # calculator
     -500001: "Invalid fields in calculation.",
@@ -210,7 +223,10 @@ _errors: typing.Dict[int, typing.Union[_TGE, str, typing.Tuple[_TGE, typing.Opti
     -2016: RedemptionCooldown,
     -2017: RedemptionClaimed,
     -2018: RedemptionClaimed,
-    -2021: (RedemptionException, "Cannot claim codes for accounts with adventure rank lower than 10."),
+    -2021: (
+        RedemptionException,
+        "Cannot claim codes for accounts with adventure rank lower than 10.",
+    ),
     # rewards
     -5003: AlreadyClaimed,
     # chinese
@@ -219,6 +235,7 @@ _errors: typing.Dict[int, typing.Union[_TGE, str, typing.Tuple[_TGE, typing.Opti
     # account
     -3208: AccountLoginFail,
     -3202: AccountHasLocked,
+    -3205: WrongOTP,
 }
 
 ERRORS: typing.Dict[int, typing.Tuple[_TGE, typing.Optional[str]]] = {

--- a/genshin/utility/geetest.py
+++ b/genshin/utility/geetest.py
@@ -4,11 +4,13 @@ import base64
 import json
 import typing
 
+from ..types import Region
+
 __all__ = ["encrypt_geetest_credentials"]
 
 
 # RSA key is the same for app and web login
-LOGIN_KEY_CERT = b"""
+OS_LOGIN_KEY_CERT = b"""
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4PMS2JVMwBsOIrYWRluY
 wEiFZL7Aphtm9z5Eu/anzJ09nB00uhW+ScrDWFECPwpQto/GlOJYCUwVM/raQpAj
@@ -17,6 +19,15 @@ ZJcGeJ95bvJ+hJ/UMP0Zx2qB5PElZmiKvfiNqVUk8A8oxLJdBB5eCpqWV6CUqDKQ
 KSQP4sM0mZvQ1Sr4UcACVcYgYnCbTZMWhJTWkrNXqI8TMomekgny3y+d6NX/cFa6
 6jozFIF4HCX5aW8bp8C8vq2tFvFbleQ/Q3CU56EWWKMrOcpmFtRmC18s9biZBVR/
 8QIDAQAB
+-----END PUBLIC KEY-----
+"""
+
+CN_LOGIN_KEY_CERT = b"""
+-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDDvekdPMHN3AYhm/vktJT+YJr7
+cI5DcsNKqdsx5DZX0gDuWFuIjzdwButrIYPNmRJ1G8ybDIF7oDW2eEpm5sMbL9zs
+9ExXCdvqrn51qELbqj0XxtMTIpaCHFSI50PfPpTFV9Xt/hmyVwokoOXFlAEgCn+Q
+CgGs52bFoYMtyi+xEQIDAQAB
 -----END PUBLIC KEY-----
 """
 
@@ -38,6 +49,16 @@ APP_LOGIN_HEADERS = {
     # "x-rpc-device_id": "1c33337bd45c1bfs",
 }
 
+CN_LOGIN_HEADERS = {
+    "x-rpc-app_id": "bll8iq97cem8",
+    "x-rpc-client_type": "4",
+    "Origin": "https://user.miyoushe.com",
+    "Referer": "https://user.miyoushe.com/",
+    "x-rpc-source": "v2.webLogin",
+    "x-rpc-mi_referrer": "https://user.miyoushe.com/login-platform/index.html?app_id=bll8iq97cem8&theme=&token_type=4&game_biz=bbs_cn&message_origin=https%253A%252F%252Fwww.miyoushe.com&succ_back_type=message%253Alogin-platform%253Alogin-success&fail_back_type=message%253Alogin-platform%253Alogin-fail&ux_mode=popup&iframe_level=1#/login/password",  # noqa: E501
+    "x-rpc-device_id": "586f2440-856a-4243-8076-2b0a12314197",
+}
+
 EMAIL_SEND_HEADERS = {
     "x-rpc-app_id": "c9oqaq3s3gu8",
     "x-rpc-client_type": "2",
@@ -49,11 +70,13 @@ EMAIL_VERIFY_HEADERS = {
 }
 
 
-def encrypt_geetest_credentials(text: str) -> str:
+def encrypt_geetest_credentials(text: str, region: Region) -> str:
     """Encrypt text for geetest."""
     import rsa
 
-    public_key = rsa.PublicKey.load_pkcs1_openssl_pem(LOGIN_KEY_CERT)
+    public_key = rsa.PublicKey.load_pkcs1_openssl_pem(
+        OS_LOGIN_KEY_CERT if region is Region.OVERSEAS else CN_LOGIN_KEY_CERT
+    )
     crypto = rsa.encrypt(text.encode("utf-8"), public_key)
     return base64.b64encode(crypto).decode("utf-8")
 

--- a/genshin/utility/geetest.py
+++ b/genshin/utility/geetest.py
@@ -70,7 +70,7 @@ EMAIL_VERIFY_HEADERS = {
 }
 
 
-def encrypt_geetest_credentials(text: str, region: Region) -> str:
+def encrypt_geetest_credentials(text: str, region: Region = Region.OVERSEAS) -> str:
     """Encrypt text for geetest."""
     import rsa
 


### PR DESCRIPTION
# About this PR
Currently genshin.py only supports login with account & password via HoYoLAB, this PR plans to add support to Miyoushe (CN HoYoLAB) as well. 

## Planned Features
- Login with email/username and password: Done
- Login with phone number + Ability to send OTP: Done
- Check mobile number validity: Done

## Other Information
- The CN password login method is currently exposed in a separate function in the `GeetestClient` called `cn_login_by_password`
- It seems like password login in Miyoushe doesn't have such thing as e-mail verification
- I'm unable to trigger CAPTCHA with password login and OTP login, so whether the retcode is correct is unknown