### PR TITLE
Improve reformat session in nox

### DIFF
--- a/genshin-dev/reformat-requirements.txt
+++ b/genshin-dev/reformat-requirements.txt
@@ -1,3 +1,2 @@
 black
 ruff
-sort-all

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -28,7 +28,6 @@ __all__ = [
     "MI18N",
     "RECORD_URL",
     "REWARD_URL",
-    "Route",
     "TAKUMI_URL",
     "TEAPOT_URL",
     "VERIFY_EMAIL_URL",
@@ -36,6 +35,7 @@ __all__ = [
     "WEBSTATIC_URL",
     "WEB_LOGIN_URL",
     "YSULOG_URL",
+    "Route",
 ]
 
 

--- a/genshin/errors.py
+++ b/genshin/errors.py
@@ -3,13 +3,13 @@
 import typing
 
 __all__ = [
+    "ERRORS",
     "AccountNotFound",
     "AlreadyClaimed",
     "AuthkeyException",
     "AuthkeyTimeout",
     "CookieException",
     "DataNotPublic",
-    "ERRORS",
     "GeetestTriggered",
     "GenshinException",
     "InvalidAuthkey",

--- a/genshin/models/honkai/chronicle/modes.py
+++ b/genshin/models/honkai/chronicle/modes.py
@@ -18,8 +18,8 @@ from genshin.models.honkai import battlesuit
 from genshin.models.model import Aliased, APIModel, Unique
 
 __all__ = [
-    "Boss",
     "ELF",
+    "Boss",
     "ElysianRealm",
     "MemorialArena",
     "MemorialBattle",

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,12 +60,21 @@ def reformat(session: nox.Session) -> None:
     """Reformat this project's modules to fit the standard style."""
     install_requirements(session, "reformat")
     session.run("python", "-m", "black", *GENERAL_TARGETS, *verbose_args())
-    session.run("python", "-m", "ruff", "check", "--fix-only", "--fixable", "ALL", *GENERAL_TARGETS, *verbose_args())
-
-    session.log("sort-all")
-    LOGGER.disabled = True
-    session.run("sort-all", *map(str, pathlib.Path(PACKAGE).glob("**/*.py")), success_codes=[0, 1])
-    LOGGER.disabled = False
+    # sort __all__ and format imports
+    session.run(
+        "python",
+        "-m",
+        "ruff",
+        "check",
+        "--preview",
+        "--select",
+        "RUF022,I",
+        "--fix",
+        *GENERAL_TARGETS,
+        *verbose_args(),
+    )
+    # fix all fixable linting errors
+    session.run("ruff", "check", "--fix", *GENERAL_TARGETS, *verbose_args())
 
 
 @nox.session(name="test")


### PR DESCRIPTION
The [RUF022](https://docs.astral.sh/ruff/rules/unsorted-dunder-all/) rule can fix `__all__`, so remove the `sort-all` package and use this rule instead.
Also add import sorting with ruff, I forgot to include it in #168. 
Also add command to fix fixable lint errors (safe fixes only).