### PR TITLE
Add Support to Resolve MiyousheGeetestError

### DIFF
--- a/genshin/client/components/auth/client.py
+++ b/genshin/client/components/auth/client.py
@@ -231,12 +231,12 @@ class AuthClient(subclients.AppAuthClient, subclients.WebAuthClient, subclients.
     async def create_mmt(self) -> MMT:
         """Create a geetest challenge."""
         is_genshin = self.game is Game.GENSHIN
+        ds_headers = ds_utility.get_ds_headers(self.region, params={"is_high": "false"})
         headers = {
-            "DS": ds_utility.generate_create_geetest_ds(),
             "x-rpc-challenge_game": "2" if is_genshin else "6",
             "x-rpc-page": "v4.1.5-ys_#ys" if is_genshin else "v1.4.1-rpg_#/rpg",
             "x-rpc-tool-verison": "v4.1.5-ys" if is_genshin else "v1.4.1-rpg",
-            **auth_utility.CREATE_MMT_HEADERS,
+            **ds_headers,
         }
 
         assert isinstance(self.cookie_manager, managers.CookieManager)

--- a/genshin/client/components/auth/client.py
+++ b/genshin/client/components/auth/client.py
@@ -277,6 +277,30 @@ class AuthClient(subclients.AppAuthClient, subclients.WebAuthClient, subclients.
         if not data["data"]:
             errors.raise_for_retcode(data)
 
+    @staticmethod
+    async def generate_device_fp() -> str:
+        """Generate a device fingerprint through the API."""
+        payload = {
+            "device_id": auth_utility.generate_device_fp(length=16),
+            "device_fp": auth_utility.generate_device_fp(),
+            "seed_id": auth_utility.generate_device_id(),
+            "seed_time": str(int(time.time() * 1000)),
+            "app_name": "bbs_cn",
+            "bbs_device_id": auth_utility.generate_device_id(),
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                routes.GET_FP_URL.get_url(),
+                json=payload,
+            ) as resp:
+                data = await resp.json()
+
+        if not data["data"]:
+            errors.raise_for_retcode(data)
+
+        return data["data"]["device_fp"]
+
     @base.region_specific(types.Region.OVERSEAS)
     async def os_game_login(
         self,

--- a/genshin/client/components/base.py
+++ b/genshin/client/components/base.py
@@ -20,6 +20,7 @@ from genshin.client import routes
 from genshin.client.manager import managers
 from genshin.models import hoyolab as hoyolab_models
 from genshin.models import model as base_model
+from genshin.models.auth.geetest import MMTResult
 from genshin.utility import concurrency, deprecation, ds
 
 __all__ = ["BaseClient"]
@@ -423,6 +424,7 @@ class BaseClient(abc.ABC):
         params: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         data: typing.Any = None,
         headers: typing.Optional[aiohttp.typedefs.LooseHeaders] = None,
+        mmt_result: typing.Optional[MMTResult] = None,
         **kwargs: typing.Any,
     ) -> typing.Mapping[str, typing.Any]:
         """Make a request any hoyolab endpoint."""
@@ -435,6 +437,8 @@ class BaseClient(abc.ABC):
         url = routes.TAKUMI_URL.get_url(region).join(yarl.URL(url))
 
         headers = dict(headers or {})
+        if mmt_result is not None:
+            headers["x-rpc-challenge"] = mmt_result.geetest_challenge
         headers.update(ds.get_ds_headers(data=data, params=params, region=region, lang=lang or self.lang))
 
         data = await self.request(url, method=method, params=params, data=data, headers=headers, **kwargs)

--- a/genshin/client/components/chronicle/base.py
+++ b/genshin/client/components/chronicle/base.py
@@ -10,6 +10,7 @@ from genshin.client import cache, routes
 from genshin.client.components import base
 from genshin.client.manager import managers
 from genshin.models import hoyolab as hoyolab_models
+from genshin.models.auth.geetest import MMTResult
 from genshin.utility import deprecation
 
 __all__ = ["BaseBattleChronicleClient"]
@@ -44,6 +45,7 @@ class BaseBattleChronicleClient(base.BaseClient):
         lang: typing.Optional[str] = None,
         region: typing.Optional[types.Region] = None,
         game: typing.Optional[types.Game] = None,
+        mmt_result: typing.Optional[MMTResult] = None,
         **kwargs: typing.Any,
     ) -> typing.Mapping[str, typing.Any]:
         """Make a request towards the game record endpoint."""
@@ -57,7 +59,7 @@ class BaseBattleChronicleClient(base.BaseClient):
         mi18n_task = asyncio.create_task(self._fetch_mi18n("bbs", lang=lang or self.lang))
         update_task = asyncio.create_task(utility.update_characters_any(lang or self.lang, lenient=True))
 
-        data = await self.request_hoyolab(url, lang=lang, region=region, **kwargs)
+        data = await self.request_hoyolab(url, lang=lang, region=region, mmt_result=mmt_result, **kwargs)
 
         await mi18n_task
         try:

--- a/genshin/client/components/chronicle/genshin.py
+++ b/genshin/client/components/chronicle/genshin.py
@@ -5,6 +5,7 @@ import functools
 import typing
 
 from genshin import errors, paginators, types, utility
+from genshin.models.auth.geetest import MMTResult
 from genshin.models.genshin import character as character_models
 from genshin.models.genshin import chronicle as models
 
@@ -25,6 +26,7 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
         lang: typing.Optional[str] = None,
         payload: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         cache: bool = True,
+        mmt_result: typing.Optional[MMTResult] = None,
     ) -> typing.Mapping[str, typing.Any]:
         """Get an arbitrary honkai object."""
         payload = dict(payload or {})
@@ -57,6 +59,7 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
             params=params,
             data=data,
             cache=cache_key,
+            mmt_result=mmt_result,
         )
 
     async def get_partial_genshin_user(
@@ -113,10 +116,11 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
         *,
         lang: typing.Optional[str] = None,
         autoauth: bool = True,
+        mmt_result: typing.Optional[MMTResult] = None,
     ) -> models.Notes:
         """Get genshin real-time notes."""
         try:
-            data = await self._request_genshin_record("dailyNote", uid, lang=lang, cache=False)
+            data = await self._request_genshin_record("dailyNote", uid, lang=lang, cache=False, mmt_result=mmt_result)
         except errors.DataNotPublic as e:
             # error raised only when real-time notes are not enabled
             if uid and (await self._get_uid(types.Game.GENSHIN)) != uid:
@@ -125,7 +129,7 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
                 raise errors.GenshinException(e.response, "Real-time notes are not enabled.") from e
 
             await self.update_settings(3, True, game=types.Game.GENSHIN)
-            data = await self._request_genshin_record("dailyNote", uid, lang=lang, cache=False)
+            data = await self._request_genshin_record("dailyNote", uid, lang=lang, cache=False, mmt_result=mmt_result)
 
         return models.Notes(**data)
 

--- a/genshin/client/manager/managers.py
+++ b/genshin/client/manager/managers.py
@@ -156,7 +156,7 @@ class BaseCookieManager(abc.ABC):
         errors.check_for_geetest(data)
 
         if data["retcode"] in MIYOUSHE_GEETEST_RETCODES:
-            raise errors.MiyousheGeetestError(data, {k: morsel.value for k, morsel in response.cookies.items()})
+            raise errors.MiyousheGeetestError(data)
 
         if data["retcode"] == 0:
             return data["data"]

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -244,6 +244,8 @@ CREATE_MMT_URL = Route(
 )
 VERIFY_MMT_URL = Route("https://api-takumi-record.mihoyo.com/game_record/app/card/wapi/verifyVerification")
 
+GET_FP_URL = Route("https://public-data-api.mihoyo.com/device-fp/api/getFp")
+
 GAME_RISKY_CHECK_URL = InternationalRoute(
     overseas="https://api-account-os.hoyoverse.com/account/risky/api/check",
     chinese="https://gameapi-account.mihoyo.com/account/risky/api/check",

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -242,6 +242,7 @@ CHECK_QRCODE_URL = Route("https://hk4e-sdk.mihoyo.com/hk4e_cn/combo/panda/qrcode
 CREATE_MMT_URL = Route(
     "https://api-takumi-record.mihoyo.com/game_record/app/card/wapi/createVerification?is_high=false"
 )
+VERIFY_MMT_URL = Route("https://api-takumi-record.mihoyo.com/game_record/app/card/wapi/verifyVerification")
 
 GAME_RISKY_CHECK_URL = InternationalRoute(
     overseas="https://api-account-os.hoyoverse.com/account/risky/api/check",

--- a/genshin/constants.py
+++ b/genshin/constants.py
@@ -75,3 +75,6 @@ APP_IDS = {
     },
 }
 """App IDs used for game login."""
+
+DEVICE_HEADERS = {"x-rpc-device_id": "441058ee-2c18-4a4b-94f0-1081d12eda92", "x-rpc-device_fp": "38d7f191c78a0"}
+"""Headers used for device information."""

--- a/genshin/errors.py
+++ b/genshin/errors.py
@@ -193,9 +193,7 @@ class MiyousheGeetestError(GenshinException):
     def __init__(
         self,
         response: typing.Dict[str, typing.Any],
-        cookies: typing.Mapping[str, str],
     ) -> None:
-        self.cookies = cookies
         super().__init__(response)
 
     msg = "Geetest triggered during Miyoushe API request."

--- a/genshin/utility/auth.py
+++ b/genshin/utility/auth.py
@@ -3,7 +3,9 @@
 import base64
 import hmac
 import json
+import random
 import typing
+import uuid
 from hashlib import sha256
 
 from genshin import constants
@@ -152,3 +154,14 @@ def generate_risky_header(
 ) -> str:
     """Generate risky header for geetest verification."""
     return f"id={check_id};c={challenge};s={validate}|jordan;v={validate}"
+
+
+def generate_device_id() -> str:
+    """Generate a random device ID."""
+    return str(uuid.uuid4()).lower()
+
+
+def generate_device_fp(length: int = 13) -> str:
+    """Generate a random device fingerprint."""
+    characters = "abcdef0123456789"
+    return "".join(random.choices(characters, k=length))

--- a/genshin/utility/auth.py
+++ b/genshin/utility/auth.py
@@ -69,11 +69,6 @@ EMAIL_VERIFY_HEADERS = {
     "x-rpc-client_type": "2",
 }
 
-CREATE_MMT_HEADERS = {
-    "x-rpc-app_version": "2.60.1",
-    "x-rpc-client_type": "5",
-}
-
 DEVICE_ID = "D6AF5103-D297-4A01-B86A-87F87DS5723E"
 
 RISKY_CHECK_HEADERS = {

--- a/genshin/utility/ds.py
+++ b/genshin/utility/ds.py
@@ -11,7 +11,6 @@ from genshin import constants, types
 
 __all__ = [
     "generate_cn_dynamic_secret",
-    "generate_create_geetest_ds",
     "generate_dynamic_secret",
     "generate_passport_ds",
     "get_ds_headers",
@@ -34,7 +33,7 @@ def generate_cn_dynamic_secret(
 ) -> str:
     """Create a new chinese dynamic secret."""
     t = int(time.time())
-    r = random.randint(100001, 200000)
+    r = random.randint(100000, 200000)
     b = json.dumps(body) if body else ""
     q = "&".join(f"{k}={v}" for k, v in sorted(query.items())) if query else ""
 
@@ -58,7 +57,7 @@ def get_ds_headers(
         }
     elif region == types.Region.CHINESE:
         ds_headers = {
-            "x-rpc-app_version": "2.11.1",
+            "x-rpc-app_version": "2.60.1",
             "x-rpc-client_type": "5",
             "ds": generate_cn_dynamic_secret(data, params),
         }
@@ -76,12 +75,3 @@ def generate_passport_ds(body: typing.Mapping[str, typing.Any]) -> str:
     h = hashlib.md5(f"salt={salt}&t={t}&r={r}&b={b}&q=".encode()).hexdigest()
     result = f"{t},{r},{h}"
     return result
-
-
-def generate_create_geetest_ds() -> str:
-    """Create a dynamic secret for Miyoushe createVerification API endpoint."""
-    salt = constants.DS_SALT[types.Region.CHINESE]
-    t = int(time.time())
-    r = random.randint(100000, 200000)
-    h = hashlib.md5(f"salt={salt}&t={t}&r={r}&b=&q=is_high=false".encode()).hexdigest()
-    return f"{t},{r},{h}"


### PR DESCRIPTION
# Summary
Miyoushe API requests will fail when any request is being sent from an unrecognized device, in a previous commit I implemented a check to raise `MiyousheGeetestError` if that is the case, but there are currently no ways of resolving those errors with the library. 
 
Here are 3 ways (that I know) to resolve the error.

## 1. Pass in Device Information (Easiest to Implement)
This requires the user to have a device that is already "trusted", typically a phone that has the Miyoushe app installed and has been logged in with the Miyoushe account for a long period of time. When requesting, pass in the information of that device through the `device_fp` and `device_id` headers, and theoretically Miyoushe will think this request is secure and will not raise the error. A possible implementation is to allow users to pass in custom headers during `genshin.Client` initialization, and the client will use them in all requests.

## 2. Solve the Geetest and Re-Request (WIP)
This is what I am currently working on, though not quite successful.  
The code snippet below is what I plan to implement this solution:
```py
import genshin

client = genshin.Client(...) # Fill in cookies, region, game and any other information
try:
      result = await client.get_genshin_notes()
except genshin.MiyousheGeetestError:
      mmt = await client.create_mmt()
      mmt_result = await server.solve_geetest(mmt, api_server="api.geetest.com", proxy_geetest=True)
      await client.verify_mmt(mmt_result)
      # Re-request
      result = await client.get_genshin_notes(mmt_result=mmt_result)
```
However, I encountered an unknown error with retcode `10306` and no error message in `verify_mmt`. So, I'm stuck.

## 3. Make the Device Become a Trusted Device
There is little information on this yet, but while looking at gsuid_core's code when I'm trying to resolve the error above, I noticed that it seems to be possible to generate random device information and make them become trusted through API requests, I will look more into this. Also, I'm thinking about adding methods to the auth client that generate random device information, but I need to figure out what `device_fp`, `device_id`, and `x-rpc-device_id` are.

# Side Notes
We don't necessarily need to implement all 3 solutions, in fact any one of them being implemented should be enough for the user.

# Task List
- [ ] Pass in Device Information
- [ ] Solve the Geetest and Re-Request
- [ ] Make the Device Become a Trusted Device