### PR TITLE
Modify HSR Pure Fiction and MOC Models

### DIFF
--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -1,6 +1,6 @@
 """Starrail chronicle challenge."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
     import pydantic.v1 as pydantic
@@ -16,7 +16,6 @@ from genshin.models.starrail.character import FloorCharacter
 from .base import PartialTime
 
 __all__ = [
-    "ChallengeSeason",
     "FictionBuff",
     "FictionFloor",
     "FictionFloorNode",
@@ -45,19 +44,10 @@ class StarRailFloor(APIModel):
     is_chaos: bool
 
 
-class ChallengeSeason(APIModel):
-    """A Memory of Chaos season."""
-
-    id: int = Aliased("schedule_id")
-    begin_time: PartialTime
-    end_time: PartialTime
-    status: Literal["Running", "End"]
-    name: str = Aliased("name_mi18n")
-
-
 class StarRailChallenge(APIModel):
     """Challenge in a season."""
 
+    name: str
     season: int = Aliased("schedule_id")
     begin_time: PartialTime
     end_time: PartialTime
@@ -68,7 +58,15 @@ class StarRailChallenge(APIModel):
     has_data: bool
 
     floors: List[StarRailFloor] = Aliased("all_floor_detail")
-    seasons: List[ChallengeSeason] = Aliased("groups")
+
+    @pydantic.root_validator(pre=True)
+    def __extract_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if "groups" in values and isinstance(values["groups"], List):
+            groups: List[Dict[str, Any]] = values["groups"]
+            if len(groups) > 0:
+                values["name"] = groups[0]["name_mi18n"]
+
+        return values
 
 
 class FictionBuff(APIModel):

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -21,6 +21,7 @@ __all__ = [
     "FictionFloorNode",
     "FloorNode",
     "StarRailChallenge",
+    "StarRailChallengeSeason",
     "StarRailFloor",
     "StarRailPureFiction",
 ]

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -58,7 +58,6 @@ class StarRailChallengeSeason(APIModel):
 class StarRailChallenge(APIModel):
     """Challenge in a season."""
 
-    name: str
     season: int = Aliased("schedule_id")
     begin_time: PartialTime
     end_time: PartialTime
@@ -70,15 +69,6 @@ class StarRailChallenge(APIModel):
 
     floors: List[StarRailFloor] = Aliased("all_floor_detail")
     seasons: List[StarRailChallengeSeason] = Aliased("groups")
-
-    @pydantic.root_validator(pre=True)
-    def __extract_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if "groups" in values and isinstance(values["groups"], List):
-            groups: List[Dict[str, Any]] = values["groups"]
-            if len(groups) > 0:
-                values["name"] = groups[0]["name_mi18n"]
-
-        return values
 
 
 class FictionBuff(APIModel):

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -1,6 +1,6 @@
 """Starrail chronicle challenge."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 if TYPE_CHECKING:
     import pydantic.v1 as pydantic
@@ -44,6 +44,16 @@ class StarRailFloor(APIModel):
     is_chaos: bool
 
 
+class ChallengeSeason(APIModel):
+    """A Memory of Chaos season."""
+
+    id: int = Aliased("schedule_id")
+    begin_time: PartialTime
+    end_time: PartialTime
+    status: Literal["Running", "End"]
+    name: str = Aliased("name_mi18n")
+
+
 class StarRailChallenge(APIModel):
     """Challenge in a season."""
 
@@ -57,6 +67,7 @@ class StarRailChallenge(APIModel):
     has_data: bool
 
     floors: List[StarRailFloor] = Aliased("all_floor_detail")
+    seasons: List[ChallengeSeason] = Aliased("groups")
 
 
 class FictionBuff(APIModel):

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -1,14 +1,6 @@
 """Starrail chronicle challenge."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
-
-if TYPE_CHECKING:
-    import pydantic.v1 as pydantic
-else:
-    try:
-        import pydantic.v1 as pydantic
-    except ImportError:
-        import pydantic
+from typing import List, Optional
 
 from genshin.models.model import Aliased, APIModel
 from genshin.models.starrail.character import FloorCharacter
@@ -107,11 +99,6 @@ class FictionFloor(APIModel):
 class StarRailPureFiction(APIModel):
     """Pure Fiction challenge in a season."""
 
-    name: str
-    season_id: int
-    begin_time: PartialTime
-    end_time: PartialTime
-
     total_stars: int = Aliased("star_num")
     max_floor: str
     total_battles: int = Aliased("battle_num")
@@ -120,15 +107,3 @@ class StarRailPureFiction(APIModel):
     floors: List[FictionFloor] = Aliased("all_floor_detail")
     seasons: List[StarRailChallengeSeason] = Aliased("groups")
     max_floor_id: int
-
-    @pydantic.root_validator(pre=True)
-    def __unnest_groups(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if "groups" in values and isinstance(values["groups"], List):
-            groups: List[Dict[str, Any]] = values["groups"]
-            if len(groups) > 0:
-                values["name"] = groups[0]["name_mi18n"]
-                values["season_id"] = groups[0]["schedule_id"]
-                values["begin_time"] = groups[0]["begin_time"]
-                values["end_time"] = groups[0]["end_time"]
-
-        return values

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -44,6 +44,16 @@ class StarRailFloor(APIModel):
     is_chaos: bool
 
 
+class StarRailChallengeSeason(APIModel):
+    """A season of a challenge."""
+
+    id: int = Aliased("schedule_id")
+    name: str = Aliased("name_mi18n")
+    status: str
+    begin_time: PartialTime
+    end_time: PartialTime
+
+
 class StarRailChallenge(APIModel):
     """Challenge in a season."""
 
@@ -58,6 +68,7 @@ class StarRailChallenge(APIModel):
     has_data: bool
 
     floors: List[StarRailFloor] = Aliased("all_floor_detail")
+    seasons: List[StarRailChallengeSeason] = Aliased("groups")
 
     @pydantic.root_validator(pre=True)
     def __extract_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -116,6 +127,7 @@ class StarRailPureFiction(APIModel):
     has_data: bool
 
     floors: List[FictionFloor] = Aliased("all_floor_detail")
+    seasons: List[StarRailChallengeSeason] = Aliased("groups")
     max_floor_id: int
 
     @pydantic.root_validator(pre=True)

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -16,6 +16,7 @@ from genshin.models.starrail.character import FloorCharacter
 from .base import PartialTime
 
 __all__ = [
+    "ChallengeSeason",
     "FictionBuff",
     "FictionFloor",
     "FictionFloorNode",


### PR DESCRIPTION
# Changes Made
- Added new field `seasons` to both models.
- Marked several fields as deprecated.

# Why
The old approach of getting data through getting the first element in the `groups` list is inaccurate, because if the user queries `get_starrail_pure_fiction(previous=True)` for example, the name of the data will be the current one, not the pervious one, since the current phase's data is always the first element in `groups`.