### PR TITLE
Prevent Enum Crashes

### DIFF
--- a/genshin/models/genshin/chronicle/notes.py
+++ b/genshin/models/genshin/chronicle/notes.py
@@ -97,7 +97,14 @@ class TaskRewardStatus(str, enum.Enum):
 class TaskReward(APIModel):
     """Status of the Commission/Task."""
 
-    status: TaskRewardStatus
+    status: typing.Union[TaskRewardStatus, str]
+
+    @pydantic.validator("status", pre=True)
+    def __prevent_enum_crash(cls, v: str) -> typing.Union[TaskRewardStatus, str]:
+        try:
+            return TaskRewardStatus(v)
+        except ValueError:
+            return v
 
 
 class AttendanceRewardStatus(str, enum.Enum):
@@ -112,8 +119,15 @@ class AttendanceRewardStatus(str, enum.Enum):
 class AttendanceReward(APIModel):
     """Status of the Encounter Point."""
 
-    status: AttendanceRewardStatus
+    status: typing.Union[AttendanceRewardStatus, str]
     progress: int
+
+    @pydantic.validator("status", pre=True)
+    def __prevent_enum_crash(cls, v: str) -> typing.Union[AttendanceRewardStatus, str]:
+        try:
+            return AttendanceRewardStatus(v)
+        except ValueError:
+            return v
 
 
 class DailyTasks(APIModel):


### PR DESCRIPTION
Enums are cool, but not cool when it crashes your bot with a `ValidationError`.
I've been bothered by specifically these two enums and today I have decided to "fix" them once and for all.
These two enums always come up with some unexpected value that even myself is not able to get, since for some reason, Pydantic doesn't tell the value that didn't match the enum. When I tried to manually call `get_genshin_notes` with the account that had the error, everything is suddenly working again, so I'm guessing it's because the status changed.