### PR TITLE
Add ZZZ gacha support + fix for Chronicled Banner

### DIFF
--- a/genshin/client/components/gacha.py
+++ b/genshin/client/components/gacha.py
@@ -85,8 +85,7 @@ class WishClient(base.BaseClient):
             game=types.Game.GENSHIN,
         )
 
-        banner_names = await self.get_banner_names(lang=lang, authkey=authkey)
-        return [models.Wish(**i, banner_name=banner_names[banner_type]) for i in data]
+        return [models.Wish(**i, banner_type=banner_type) for i in data]
 
     async def _get_warp_page(
         self,
@@ -136,7 +135,7 @@ class WishClient(base.BaseClient):
         end_id: int = 0,
     ) -> paginators.Paginator[models.Wish]:
         """Get the wish history of a user."""
-        banner_types = banner_type or [100, 200, 301, 302]
+        banner_types = banner_type or [100, 200, 301, 302, 500]
 
         if not isinstance(banner_types, typing.Sequence):
             banner_types = [banner_types]

--- a/genshin/client/components/gacha.py
+++ b/genshin/client/components/gacha.py
@@ -64,7 +64,7 @@ class WishClient(base.BaseClient):
             lang=lang,
             game=game,
             authkey=authkey,
-            params=dict(gacha_type=banner_type, size=20, end_id=end_id),
+            params=dict(gacha_type=banner_type, real_gacha_type=banner_type, size=20, end_id=end_id),
         )
         return data["list"]
 
@@ -106,6 +106,25 @@ class WishClient(base.BaseClient):
         )
 
         return [models.Warp(**i, banner_type=banner_type) for i in data]
+
+    async def _get_signal_page(
+        self,
+        end_id: int,
+        banner_type: models.ZZZBannerType,
+        *,
+        lang: typing.Optional[str] = None,
+        authkey: typing.Optional[str] = None,
+    ) -> typing.Sequence[models.SignalSearch]:
+        """Get a single page of warps."""
+        data = await self._get_gacha_page(
+            end_id=end_id,
+            banner_type=banner_type,
+            lang=lang,
+            authkey=authkey,
+            game=types.Game.ZZZ,
+        )
+
+        return [models.SignalSearch(**i, banner_type=banner_type) for i in data]
 
     def wish_history(
         self,
@@ -164,6 +183,41 @@ class WishClient(base.BaseClient):
                     functools.partial(
                         self._get_warp_page,
                         banner_type=typing.cast(models.StarRailBannerType, banner),
+                        lang=lang,
+                        authkey=authkey,
+                    ),
+                    limit=limit,
+                    end_id=end_id,
+                )
+            )
+
+        if len(iterators) == 1:
+            return iterators[0]
+
+        return paginators.MergedPaginator(iterators, key=lambda wish: wish.time.timestamp())
+
+    def signal_history(
+        self,
+        banner_type: typing.Optional[typing.Union[int, typing.Sequence[int]]] = None,
+        *,
+        limit: typing.Optional[int] = None,
+        lang: typing.Optional[str] = None,
+        authkey: typing.Optional[str] = None,
+        end_id: int = 0,
+    ) -> paginators.Paginator[models.SignalSearch]:
+        """Get the signal search history of a user."""
+        banner_types = banner_type or [1, 2, 3, 5]
+
+        if not isinstance(banner_types, typing.Sequence):
+            banner_types = [banner_types]
+
+        iterators: typing.List[paginators.Paginator[models.SignalSearch]] = []
+        for banner in banner_types:
+            iterators.append(
+                paginators.CursorPaginator(
+                    functools.partial(
+                        self._get_signal_page,
+                        banner_type=typing.cast(models.ZZZBannerType, banner),
                         lang=lang,
                         authkey=authkey,
                     ),

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -222,10 +222,12 @@ GACHA_URL = GameRoute(
     overseas=dict(
         genshin="https://hk4e-api-os.hoyoverse.com/gacha_info/api/",
         hkrpg="https://api-os-takumi.mihoyo.com/common/gacha_record/api/",
+        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/"
     ),
     chinese=dict(
         genshin="https://hk4e-api.mihoyo.com/event/gacha_info/api/",
         hkrpg="https://api-takumi.mihoyo.com/common/gacha_record/api/",
+        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/"
     ),
 )
 YSULOG_URL = InternationalRoute(

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -227,7 +227,7 @@ GACHA_URL = GameRoute(
     chinese=dict(
         genshin="https://hk4e-api.mihoyo.com/event/gacha_info/api/",
         hkrpg="https://api-takumi.mihoyo.com/common/gacha_record/api/",
-        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/",
+        nap="https://public-operation-nap.mihoyo.com/common/gacha_record/api/",
     ),
 )
 YSULOG_URL = InternationalRoute(

--- a/genshin/client/routes.py
+++ b/genshin/client/routes.py
@@ -222,12 +222,12 @@ GACHA_URL = GameRoute(
     overseas=dict(
         genshin="https://hk4e-api-os.hoyoverse.com/gacha_info/api/",
         hkrpg="https://api-os-takumi.mihoyo.com/common/gacha_record/api/",
-        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/"
+        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/",
     ),
     chinese=dict(
         genshin="https://hk4e-api.mihoyo.com/event/gacha_info/api/",
         hkrpg="https://api-takumi.mihoyo.com/common/gacha_record/api/",
-        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/"
+        nap="https://public-operation-nap-sg.hoyoverse.com/common/gacha_record/api/",
     ),
 )
 YSULOG_URL = InternationalRoute(

--- a/genshin/models/genshin/gacha.py
+++ b/genshin/models/genshin/gacha.py
@@ -96,7 +96,7 @@ class Wish(APIModel, Unique):
     rarity: int = Aliased("rank_type")
     time: datetime.datetime
 
-    banner_type: GenshinBannerType = Aliased("gacha_type")
+    banner_type: GenshinBannerType
 
     @pydantic.validator("banner_type", pre=True)
     def __cast_banner_type(cls, v: typing.Any) -> int:
@@ -135,7 +135,7 @@ class SignalSearch(APIModel, Unique):
     rarity: int = Aliased("rank_type")
     time: datetime.datetime
 
-    banner_type: ZZZBannerType = Aliased("gacha_type")
+    banner_type: ZZZBannerType
 
     @pydantic.validator("banner_type", pre=True)
     def __cast_banner_type(cls, v: typing.Any) -> int:

--- a/genshin/models/genshin/gacha.py
+++ b/genshin/models/genshin/gacha.py
@@ -21,8 +21,10 @@ __all__ = [
     "BannerDetailsUpItem",
     "GachaItem",
     "GenshinBannerType",
+    "ZZZBannerType",
     "Warp",
     "Wish",
+    "SignalSearch",
 ]
 
 
@@ -64,6 +66,22 @@ class StarRailBannerType(enum.IntEnum):
     """Rotating weapon banner."""
 
 
+class ZZZBannerType(enum.IntEnum):
+    """Banner types in wish histories."""
+
+    STANDARD = PERMANENT = 1
+    """Permanent standard banner."""
+
+    CHARACTER = 2
+    """Rotating character banner."""
+
+    WEAPON = 3
+    """Rotating weapon banner."""
+
+    BANGBOO = 5
+    """Bangboo banner."""
+
+
 class Wish(APIModel, Unique):
     """Wish made on any banner."""
 
@@ -97,6 +115,25 @@ class Warp(APIModel, Unique):
 
     banner_type: StarRailBannerType
     banner_id: int = Aliased("gacha_id")
+
+    @pydantic.validator("banner_type", pre=True)
+    def __cast_banner_type(cls, v: typing.Any) -> int:
+        return int(v)
+
+
+class SignalSearch(APIModel, Unique):
+    """Signal Search made on any banner."""
+
+    uid: int
+
+    id: int
+    item_id: int
+    type: str = Aliased("item_type")
+    name: str
+    rarity: int = Aliased("rank_type")
+    time: datetime.datetime
+
+    banner_type: ZZZBannerType = Aliased("gacha_type")
 
     @pydantic.validator("banner_type", pre=True)
     def __cast_banner_type(cls, v: typing.Any) -> int:

--- a/genshin/models/genshin/gacha.py
+++ b/genshin/models/genshin/gacha.py
@@ -43,6 +43,9 @@ class GenshinBannerType(enum.IntEnum):
     WEAPON = 302
     """Rotating weapon banner."""
 
+    CHRONICLED = 500
+    """Chronicled banner."""
+
     # these are special cases
     # they exist inside the history but should be counted as the same
 
@@ -94,7 +97,6 @@ class Wish(APIModel, Unique):
     time: datetime.datetime
 
     banner_type: GenshinBannerType = Aliased("gacha_type")
-    banner_name: str
 
     @pydantic.validator("banner_type", pre=True)
     def __cast_banner_type(cls, v: typing.Any) -> int:

--- a/genshin/models/genshin/gacha.py
+++ b/genshin/models/genshin/gacha.py
@@ -21,10 +21,10 @@ __all__ = [
     "BannerDetailsUpItem",
     "GachaItem",
     "GenshinBannerType",
-    "ZZZBannerType",
+    "SignalSearch",
     "Warp",
     "Wish",
-    "SignalSearch",
+    "ZZZBannerType",
 ]
 
 


### PR DESCRIPTION
# About this PR
This PR adds support for Zenless Zone Zero's gacha (Signal Searches). It also fixes an issue with Genshin's gacha and not parsing wishes on the Chronicled Banner.

# Notes
- For ZZZ's gacha, “real_gacha_type” is used in requests. The “gacha_type” values typically start with 200 (e.g., 2001 for standard banner, 2002 for character banner, etc.). However, the Bangboo banner doesn’t return any values for "2005" (the Bangboo banner’s real_gacha_type is 5). I couldn’t figure out the gacha_type value for the banner, but it seems safe to keep the real_gacha_type for now, as Genshin and HSR still parse correctly even with the real_gacha_type parameter included.
- I had to remove banner_name from the Genshin Wish model as the Chronicled banner isn't returned from the "get_banner_names" method (most likely due to the fact that the banner isn't active right now) and I could not parse the banner with banner_name included.