### PR TITLE
Add boss kills and sub-area explorations to the Exploration model and Long-Term Encounter points

### DIFF
--- a/genshin/models/genshin/chronicle/notes.py
+++ b/genshin/models/genshin/chronicle/notes.py
@@ -141,6 +141,9 @@ class DailyTasks(APIModel):
     attendance_rewards: typing.Sequence[AttendanceReward]
     attendance_visible: bool
 
+    stored_attendance: float
+    stored_attendance_refresh_countdown: datetime.timedelta = Aliased("attendance_refresh_time")
+
 
 class ArchonQuestStatus(str, enum.Enum):
     """Archon quest status."""

--- a/genshin/models/genshin/chronicle/stats.py
+++ b/genshin/models/genshin/chronicle/stats.py
@@ -123,24 +123,6 @@ class Exploration(APIModel):
 
         return offerings
 
-    @pydantic.validator("boss_list", pre=True)
-    def _add_base_boss_list(
-        cls,
-        boss_list: typing.Sequence[typing.Any],
-    ):
-        if not boss_list:
-            return []
-        return [BossKill(**boss) for boss in boss_list]
-
-    @pydantic.validator("area_exploration_list", pre=True)
-    def _add_base_area_exploration_list(
-        cls,
-        area_exploration_list: typing.Sequence[typing.Any],
-    ):
-        if not area_exploration_list:
-            return []
-        return [AreaExploration(**area) for area in area_exploration_list]
-
 
 class TeapotRealm(APIModel):
     """A specific teapot realm."""

--- a/genshin/models/genshin/chronicle/stats.py
+++ b/genshin/models/genshin/chronicle/stats.py
@@ -17,12 +17,12 @@ from genshin.models.model import Aliased, APIModel
 from . import abyss, activities, characters
 
 __all__ = [
+    "AreaExploration",
+    "BossKill",
     "Exploration",
     "FullGenshinUserStats",
     "GenshinUserStats",
     "Offering",
-    "BossKill",
-    "AreaExploration",
     "PartialGenshinUserStats",
     "Stats",
     "Teapot",
@@ -75,7 +75,7 @@ class BossKill(APIModel):
     """Boss kills in exploration"""
 
     name: str
-    kills: int = Aliased('kill_num')
+    kills: int = Aliased("kill_num")
 
 
 class AreaExploration(APIModel):
@@ -106,7 +106,7 @@ class Exploration(APIModel):
     offerings: typing.Sequence[Offering]
     boss_list: typing.Optional[typing.Sequence[BossKill]]
     area_exploration_list: typing.Optional[typing.Sequence[AreaExploration]]
-    
+
     @property
     def explored(self) -> float:
         """The percentage explored."""
@@ -125,8 +125,8 @@ class Exploration(APIModel):
 
     @pydantic.validator("boss_list", pre=True)
     def _add_base_boss_list(
-            cls,
-            boss_list: typing.Sequence[typing.Any],
+        cls,
+        boss_list: typing.Sequence[typing.Any],
     ):
         if not boss_list:
             return None
@@ -134,8 +134,8 @@ class Exploration(APIModel):
 
     @pydantic.validator("area_exploration_list", pre=True)
     def _add_base_area_exploration_list(
-            cls,
-            area_exploration_list: typing.Sequence[typing.Any],
+        cls,
+        area_exploration_list: typing.Sequence[typing.Any],
     ):
         if not area_exploration_list:
             return None

--- a/genshin/models/genshin/chronicle/stats.py
+++ b/genshin/models/genshin/chronicle/stats.py
@@ -84,6 +84,11 @@ class AreaExploration(APIModel):
     name: str
     raw_explored: int = Aliased("exploration_percentage")
 
+    @property
+    def explored(self) -> float:
+        """The percentage explored. (Note: This can go above 100%)"""
+        return self.raw_explored / 10
+
 
 class Exploration(APIModel):
     """Exploration data."""

--- a/genshin/models/genshin/chronicle/stats.py
+++ b/genshin/models/genshin/chronicle/stats.py
@@ -104,8 +104,8 @@ class Exploration(APIModel):
     map_url: str
 
     offerings: typing.Sequence[Offering]
-    boss_list: typing.Optional[typing.Sequence[BossKill]]
-    area_exploration_list: typing.Optional[typing.Sequence[AreaExploration]]
+    boss_list: typing.Sequence[BossKill]
+    area_exploration_list: typing.Sequence[AreaExploration]
 
     @property
     def explored(self) -> float:
@@ -129,7 +129,7 @@ class Exploration(APIModel):
         boss_list: typing.Sequence[typing.Any],
     ):
         if not boss_list:
-            return None
+            return []
         return [BossKill(**boss) for boss in boss_list]
 
     @pydantic.validator("area_exploration_list", pre=True)
@@ -138,7 +138,7 @@ class Exploration(APIModel):
         area_exploration_list: typing.Sequence[typing.Any],
     ):
         if not area_exploration_list:
-            return None
+            return []
         return [AreaExploration(**area) for area in area_exploration_list]
 
 

--- a/genshin/models/genshin/chronicle/stats.py
+++ b/genshin/models/genshin/chronicle/stats.py
@@ -21,6 +21,8 @@ __all__ = [
     "FullGenshinUserStats",
     "GenshinUserStats",
     "Offering",
+    "BossKill",
+    "AreaExploration",
     "PartialGenshinUserStats",
     "Stats",
     "Teapot",
@@ -69,6 +71,20 @@ class Offering(APIModel):
     icon: str = ""
 
 
+class BossKill(APIModel):
+    """Boss kills in exploration"""
+
+    name: str
+    kills: int = Aliased('kill_num')
+
+
+class AreaExploration(APIModel):
+    """Area exploration data."""
+
+    name: str
+    raw_explored: int = Aliased("exploration_percentage")
+
+
 class Exploration(APIModel):
     """Exploration data."""
 
@@ -88,7 +104,9 @@ class Exploration(APIModel):
     map_url: str
 
     offerings: typing.Sequence[Offering]
-
+    boss_list: typing.Optional[typing.Sequence[BossKill]]
+    area_exploration_list: typing.Optional[typing.Sequence[AreaExploration]]
+    
     @property
     def explored(self) -> float:
         """The percentage explored."""
@@ -104,6 +122,24 @@ class Exploration(APIModel):
             offerings = [*offerings, dict(name=values["type"], level=values["level"])]
 
         return offerings
+
+    @pydantic.validator("boss_list", pre=True)
+    def _add_base_boss_list(
+            cls,
+            boss_list: typing.Sequence[typing.Any],
+    ):
+        if not boss_list:
+            return None
+        return [BossKill(**boss) for boss in boss_list]
+
+    @pydantic.validator("area_exploration_list", pre=True)
+    def _add_base_area_exploration_list(
+            cls,
+            area_exploration_list: typing.Sequence[typing.Any],
+    ):
+        if not area_exploration_list:
+            return None
+        return [AreaExploration(**area) for area in area_exploration_list]
 
 
 class TeapotRealm(APIModel):


### PR DESCRIPTION
# About this PR
- This PR adds 2 optional fields to the Exploration model that are present on HoYoLab (Boss kills and area explorations for sub-regions)
- Also adds long term encounter points to DailyTasks

# Notes
- Certain regions have extra info returned in the API and the one region that got both is Fontaine:
![image](https://github.com/user-attachments/assets/7bd6a77f-f864-430d-a7f1-7208c98fec92)

- All main regions (Mondstadt, Liyue, Inazuma, Sumeru and Fontaine) have the area exploration percentages, but currently only Chenyu Vale and Fontaine have boss kills.
- It also seems like the area exploration percentages go above 1000 (100%) even though it only displays up to 100% on HoYoLab. This is not the case for the main exploration percentages that don't go above 1000  

- Also adds the long term encounter points to notes, added in 4.8
![image](https://github.com/user-attachments/assets/f6de63f4-006c-48f3-bc6d-0f582c618f92)

*(I've also tested this on 3 different accounts and it didn't cause any errors.)*