### PR TITLE
Fix Honkai Battle Chronicle Component

### DIFF
--- a/genshin/client/components/chronicle/honkai.py
+++ b/genshin/client/components/chronicle/honkai.py
@@ -3,7 +3,7 @@
 import asyncio
 import typing
 
-from genshin import errors, types, utility
+from genshin import errors, types
 from genshin.models.honkai import chronicle as models
 
 from . import base
@@ -34,12 +34,13 @@ class HonkaiBattleChronicleClient(base.BaseBattleChronicleClient):
                 lang=lang or self.lang,
             )
 
+        account = await self._get_account(types.Game.HONKAI)
         return await self.request_game_record(
             endpoint,
             lang=lang,
             game=types.Game.HONKAI,
-            region=types.Region.OVERSEAS,
-            params=dict(role_id=uid, server=utility.recognize_honkai_server(uid)),
+            region=self.region,
+            params=dict(server=account.server, role_id=uid),
             cache=cache_key,
         )
 

--- a/genshin/utility/uid.py
+++ b/genshin/utility/uid.py
@@ -1,6 +1,7 @@
 """Utility functions related to genshin."""
 
 import typing
+import warnings
 
 from genshin import types
 
@@ -99,6 +100,7 @@ def get_prod_game_biz(region: types.Region, game: types.Game) -> str:
 
 def recognize_honkai_server(uid: int) -> str:
     """Recognizes which server a Honkai UID is from."""
+    warnings.warn("recognize_honkai_server is unreliable, avoid using it.")
     if 10000000 < uid < 100000000:
         return "overseas01"
     elif 100000000 < uid < 200000000:
@@ -138,8 +140,6 @@ def recognize_zzz_server(uid: int) -> str:
 
 def recognize_server(uid: int, game: types.Game) -> str:
     """Recognizes which server a UID is from."""
-    if game is types.Game.HONKAI:
-        return recognize_honkai_server(uid)
     if game is types.Game.GENSHIN:
         return recognize_genshin_server(uid)
     if game is types.Game.STARRAIL:


### PR DESCRIPTION
# Summary
This PR provides fixes to the Honkai Impact 3rd battle chronicle component.
More specifically, the component was requesting the wrong server due to `recognize_honkai_server` returning the wrong server ID based on the game UID; moreover, `request_honkai_record` for CN region was not working because the request region is somehow hardcoded to `OVERSEAS` (I was shocked finding this out.)

## Changes
- Deprecated `recognize_honkai_server` because it is unreliable, fetch server ID from API instead.
- Removed hardcoded `OVERSEAS` region in `request_honkai_record`.