### PR TITLE
Make ShiyuDefense begin_time and end_time Optional

### DIFF
--- a/genshin/models/zzz/chronicle/challenge.py
+++ b/genshin/models/zzz/chronicle/challenge.py
@@ -114,8 +114,8 @@ class ShiyuDefense(APIModel):
     """ZZZ Shiyu Defense model."""
 
     schedule_id: int
-    begin_time: datetime.datetime = Aliased("hadal_begin_time")
-    end_time: datetime.datetime = Aliased("hadal_end_time")
+    begin_time: typing.Optional[datetime.datetime] = Aliased("hadal_begin_time")
+    end_time: typing.Optional[datetime.datetime] = Aliased("hadal_end_time")
     has_data: bool
     ratings: typing.Mapping[typing.Literal["S", "A", "B"], int] = Aliased("rating_list")
     floors: typing.List[ShiyuDefenseFloor] = Aliased("all_floor_detail")
@@ -133,8 +133,10 @@ class ShiyuDefense(APIModel):
     @pydantic.validator("begin_time", "end_time", pre=True)
     @classmethod
     def __add_timezone(
-        cls, v: typing.Dict[typing.Literal["year", "month", "day", "hour", "minute", "second"], int]
-    ) -> datetime.datetime:
-        return datetime.datetime(
-            v["year"], v["month"], v["day"], v["hour"], v["minute"], v["second"], tzinfo=CN_TIMEZONE
-        )
+        cls, v: typing.Optional[typing.Dict[typing.Literal["year", "month", "day", "hour", "minute", "second"], int]]
+    ) -> typing.Optional[datetime.datetime]:
+        if v is not None:
+            return datetime.datetime(
+                v["year"], v["month"], v["day"], v["hour"], v["minute"], v["second"], tzinfo=CN_TIMEZONE
+            )
+        return None


### PR DESCRIPTION
`hadal_begin_time` and `hadal_end_time` are returned as null if the player has not challenge this season's Shiyu Defense yet.

```json
{
  "retcode": 0,
  "message": "OK",
  "data": {
    "schedule_id": 0,
    "begin_time": "0",
    "end_time": "0",
    "rating_list": [],
    "has_data": false,
    "all_floor_detail": [],
    "fast_layer_time": 0,
    "max_layer": 0,
    "hadal_begin_time": null,
    "hadal_end_time": null
  }
}
```

This can cause `get_shiyu_defense` to fail Pydantic validation. This PR addresses this by making both `ShiyuDefense.begin_time` and `ShiyuDefense.end_time` Optionals.