### PR TITLE
Implement detailed Genshin character endpoint.

### DIFF
--- a/genshin/client/components/chronicle/genshin.py
+++ b/genshin/client/components/chronicle/genshin.py
@@ -79,6 +79,21 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
         data = await self._request_genshin_record("character", uid, lang=lang, method="POST")
         return [models.Character(**i) for i in data["avatars"]]
 
+    async def get_genshin_detailed_characters(
+            self,
+            uid: int,
+            *,
+            characters: typing.Sequence[int] = None,
+            lang: typing.Optional[str] = None,
+    ) -> models.GenshinDetailCharacters:
+        """Returns a list of genshin characters with full details."""
+        if characters is None:  # If characters aren't provided, fetch the list of owned ID's first as they're required in the payload.
+            character_data = await self._request_genshin_record("character/list", uid, lang=lang, method="POST")
+            characters = [char["id"] for char in character_data["list"]]
+
+        data = await self._request_genshin_record("character/detail", uid, lang=lang, method="POST", payload={"character_ids": (*characters, )})
+        return models.GenshinDetailCharacters(**data)
+
     async def get_genshin_user(
         self,
         uid: int,

--- a/genshin/client/components/chronicle/genshin.py
+++ b/genshin/client/components/chronicle/genshin.py
@@ -83,7 +83,7 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
         self,
         uid: int,
         *,
-        characters: typing.Sequence[int] = None,
+        characters: typing.Optional[typing.Sequence[int]] = None,
         lang: typing.Optional[str] = None,
     ) -> models.GenshinDetailCharacters:
         """Return a list of genshin characters with full details."""

--- a/genshin/client/components/chronicle/genshin.py
+++ b/genshin/client/components/chronicle/genshin.py
@@ -80,18 +80,22 @@ class GenshinBattleChronicleClient(base.BaseBattleChronicleClient):
         return [models.Character(**i) for i in data["avatars"]]
 
     async def get_genshin_detailed_characters(
-            self,
-            uid: int,
-            *,
-            characters: typing.Sequence[int] = None,
-            lang: typing.Optional[str] = None,
+        self,
+        uid: int,
+        *,
+        characters: typing.Sequence[int] = None,
+        lang: typing.Optional[str] = None,
     ) -> models.GenshinDetailCharacters:
-        """Returns a list of genshin characters with full details."""
-        if characters is None:  # If characters aren't provided, fetch the list of owned ID's first as they're required in the payload.
+        """Return a list of genshin characters with full details."""
+        if (
+            characters is None
+        ):  # If characters aren't provided, fetch the list of owned ID's first as they're required in the payload.
             character_data = await self._request_genshin_record("character/list", uid, lang=lang, method="POST")
             characters = [char["id"] for char in character_data["list"]]
 
-        data = await self._request_genshin_record("character/detail", uid, lang=lang, method="POST", payload={"character_ids": (*characters, )})
+        data = await self._request_genshin_record(
+            "character/detail", uid, lang=lang, method="POST", payload={"character_ids": (*characters,)}
+        )
         return models.GenshinDetailCharacters(**data)
 
     async def get_genshin_user(

--- a/genshin/models/genshin/chronicle/characters.py
+++ b/genshin/models/genshin/chronicle/characters.py
@@ -1,4 +1,5 @@
 """Genshin chronicle character."""
+
 import enum
 import typing
 
@@ -15,23 +16,23 @@ from genshin.models.model import Aliased, APIModel, Unique
 
 __all__ = [
     "Artifact",
+    "ArtifactProperty",
     "ArtifactSet",
     "ArtifactSetEffect",
     "Character",
+    "CharacterSkill",
     "CharacterWeapon",
     "Constellation",
+    "DetailArtifact",
+    "DetailCharacterWeapon",
+    "GenshinDetailCharacter",
+    "GenshinDetailCharacters",
+    "GenshinWeaponType",
     "Outfit",
     "PartialCharacter",
     "PropertyType",
     "PropertyValue",
-    "DetailCharacterWeapon",
-    "ArtifactProperty",
-    "DetailArtifact",
     "SkillAffix",
-    "CharacterSkill",
-    "GenshinDetailCharacter",
-    "GenshinDetailCharacters",
-    "GenshinWeaponType"
 ]
 
 
@@ -156,15 +157,16 @@ class PropertyType(APIModel):
 
     @pydantic.root_validator(pre=True)
     def __fix_names(cls, values: typing.Mapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]:
-        """Fix "\xa0" in Crit Damage + Crit Rate names."""
+        r"""Fix "\xa0" in Crit Damage + Crit Rate names."""
         name = values.get("name")
         filter_name = values.get("filter_name")
 
-        return {**values, "name": name.replace(u"\xa0", " "), "filter_name": filter_name.replace(u"\xa0", " ")}
+        return {**values, "name": name.replace("\xa0", " "), "filter_name": filter_name.replace("\xa0", " ")}
 
 
 class PropertyValue(APIModel):
     """A property with a value."""
+
     base: str
     add: str
     final: str
@@ -173,27 +175,36 @@ class PropertyValue(APIModel):
 
 class DetailCharacterWeapon(CharacterWeapon):
     """Detailed Genshin Weapon with main/sub stats."""
+
     main_property: PropertyValue
     sub_property: typing.Optional[PropertyValue]
 
 
 class ArtifactProperty(APIModel):
+    """Artifact's Property value & roll count."""
+
     value: str
     times: int
     info: PropertyType
 
 
 class DetailArtifact(Artifact):
+    """Detailed artifact with main/sub stats."""
+
     main_property: ArtifactProperty
     sub_properties: typing.Sequence[ArtifactProperty] = Aliased("sub_property_list")
 
 
 class SkillAffix(APIModel):
+    """Skill affix texts."""
+
     name: str
     value: str
 
 
 class CharacterSkill(APIModel):
+    """Character's skill."""
+
     id: int = Aliased("skill_id")
     skill_type: int
     name: str
@@ -207,6 +218,7 @@ class CharacterSkill(APIModel):
 
 class GenshinDetailCharacter(PartialCharacter):
     """Full Detailed Genshin Character"""
+
     is_chosen: bool
 
     # display_image is a different image that is returned by the full character endpoint, but it is not the full gacha art.
@@ -276,7 +288,12 @@ class GenshinDetailCharacters(APIModel):
                     sub_property["info"] = property_map.get(str(sub_property["property_type"]), {})
 
             # Map character properties
-            for prop in char['base_properties'] + char['selected_properties'] + char['extra_properties'] + char['element_properties']:
-                prop['info'] = property_map.get(str(prop['property_type']), {})
+            for prop in (
+                char["base_properties"]
+                + char["selected_properties"]
+                + char["extra_properties"]
+                + char["element_properties"]
+            ):
+                prop["info"] = property_map.get(str(prop["property_type"]), {})
 
         return values

--- a/genshin/models/genshin/chronicle/characters.py
+++ b/genshin/models/genshin/chronicle/characters.py
@@ -2,6 +2,7 @@
 
 import enum
 import typing
+from collections import defaultdict
 
 if typing.TYPE_CHECKING:
     import pydantic.v1 as pydantic
@@ -130,15 +131,16 @@ class Character(PartialCharacter):
     outfits: typing.Sequence[Outfit] = Aliased("costumes")
 
     @pydantic.validator("artifacts")
-    def __add_artifact_effect_enabled(cls, artifacts: typing.Sequence[Artifact]) -> typing.Sequence[Artifact]:
-        sets: typing.Dict[int, typing.List[Artifact]] = {}
+    @classmethod
+    def __enable_artifact_set_effects(cls, artifacts: typing.Sequence[Artifact]) -> typing.Sequence[Artifact]:
+        set_nums: typing.DefaultDict[int, int] = defaultdict(int)
         for arti in artifacts:
-            sets.setdefault(arti.set.id, []).append(arti)
+            set_nums[arti.set.id] += 1
 
         for artifact in artifacts:
             for effect in artifact.set.effects:
-                if effect.pieces <= len(sets[artifact.set.id]):
-                    effect.enabled = True
+                if effect.required_piece_num <= set_nums[artifact.set.id]:
+                    effect.active = True
 
         return artifacts
 

--- a/genshin/models/genshin/chronicle/characters.py
+++ b/genshin/models/genshin/chronicle/characters.py
@@ -158,10 +158,10 @@ class PropertyType(APIModel):
     @pydantic.root_validator(pre=True)
     def __fix_names(cls, values: typing.Mapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]:
         r"""Fix "\xa0" in Crit Damage + Crit Rate names."""
-        name = values.get("name")
-        filter_name = values.get("filter_name")
+        name = values.get("name", "")
+        filter_name = values.get("filter_name", "")
 
-        return {**values, "name": name.replace("\xa0", " "), "filter_name": filter_name.replace("\xa0", " ")}
+        return {**values, "name": str(name).replace("\xa0", " "), "filter_name": str(filter_name).replace("\xa0", " ")}
 
 
 class PropertyValue(APIModel):

--- a/genshin/models/genshin/chronicle/characters.py
+++ b/genshin/models/genshin/chronicle/characters.py
@@ -1,5 +1,5 @@
 """Genshin chronicle character."""
-
+import enum
 import typing
 
 if typing.TYPE_CHECKING:
@@ -22,7 +22,27 @@ __all__ = [
     "Constellation",
     "Outfit",
     "PartialCharacter",
+    "PropertyType",
+    "PropertyValue",
+    "DetailCharacterWeapon",
+    "ArtifactProperty",
+    "DetailArtifact",
+    "SkillAffix",
+    "CharacterSkill",
+    "GenshinDetailCharacter",
+    "GenshinDetailCharacters",
+    "GenshinWeaponType"
 ]
+
+
+class GenshinWeaponType(enum.IntEnum):
+    """Character weapon types."""
+
+    SWORD = 1
+    CATALYST = 10
+    CLAYMORE = 11
+    BOW = 12
+    POLEARM = 13
 
 
 class PartialCharacter(character.BaseCharacter):
@@ -124,3 +144,139 @@ class Character(PartialCharacter):
                     effect.enabled = True
 
         return artifacts
+
+
+class PropertyType(APIModel):
+    """A property such as Crit Rate, HP, HP%."""
+
+    property_type: int
+    name: str
+    icon: typing.Optional[str]
+    filter_name: str
+
+    @pydantic.root_validator(pre=True)
+    def __fix_names(cls, values: typing.Mapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]:
+        """Fix "\xa0" in Crit Damage + Crit Rate names."""
+        name = values.get("name")
+        filter_name = values.get("filter_name")
+
+        return {**values, "name": name.replace(u"\xa0", " "), "filter_name": filter_name.replace(u"\xa0", " ")}
+
+
+class PropertyValue(APIModel):
+    """A property with a value."""
+    base: str
+    add: str
+    final: str
+    info: PropertyType
+
+
+class DetailCharacterWeapon(CharacterWeapon):
+    """Detailed Genshin Weapon with main/sub stats."""
+    main_property: PropertyValue
+    sub_property: typing.Optional[PropertyValue]
+
+
+class ArtifactProperty(APIModel):
+    value: str
+    times: int
+    info: PropertyType
+
+
+class DetailArtifact(Artifact):
+    main_property: ArtifactProperty
+    sub_properties: typing.Sequence[ArtifactProperty] = Aliased("sub_property_list")
+
+
+class SkillAffix(APIModel):
+    name: str
+    value: str
+
+
+class CharacterSkill(APIModel):
+    id: int = Aliased("skill_id")
+    skill_type: int
+    name: str
+    level: int
+
+    description: str = Aliased("desc")
+    affixes: typing.Sequence[SkillAffix] = Aliased("skill_affix_list")
+    icon: str
+    is_unlocked: bool = Aliased("is_unlock")
+
+
+class GenshinDetailCharacter(PartialCharacter):
+    """Full Detailed Genshin Character"""
+    is_chosen: bool
+
+    # display_image is a different image that is returned by the full character endpoint, but it is not the full gacha art.
+    display_image: str = Aliased("image")
+
+    weapon_type: GenshinWeaponType
+    weapon: DetailCharacterWeapon
+
+    costumes: typing.Sequence[Outfit]
+
+    artifacts: typing.Sequence[DetailArtifact] = Aliased("relics")
+    constellations: typing.Sequence[Constellation]
+
+    skills: typing.Sequence[CharacterSkill]
+
+    selected_properties: typing.Sequence[PropertyValue]
+    base_properties: typing.Sequence[PropertyValue]
+    extra_properties: typing.Sequence[PropertyValue]
+    element_properties: typing.Sequence[PropertyValue]
+
+
+class GenshinDetailCharacters(APIModel):
+    """Genshin character list."""
+
+    avatars: typing.Sequence[GenshinDetailCharacter] = Aliased("list")
+
+    property_map: typing.Mapping[str, PropertyType]
+    artifact_property_options: typing.Mapping[str, typing.Sequence[PropertyType]] = Aliased("relic_property_options")
+
+    artifact_wiki: typing.Mapping[str, str] = Aliased("relic_wiki")
+    weapon_wiki: typing.Mapping[str, str]
+    avatar_wiki: typing.Mapping[str, str]
+
+    @pydantic.root_validator(pre=True)
+    def __fill_additional_fields(cls, values: typing.Mapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]:
+        """Fill additional fields for convenience."""
+        relic_property_options = values.get("artifact_property_options", {})
+        property_map = values.get("property_map", {})
+        characters = values.get("avatars", [])
+
+        # Map properties to artifacts
+        for relic_type, properties in relic_property_options.items():
+            formatted_properties = []
+            for prop in properties:
+                prop = property_map.get(str(prop), {})
+                formatted_properties.append(prop)
+            relic_property_options[relic_type] = formatted_properties
+
+        for char in characters:
+            # Extract character info from .base
+            for key, value in char["base"].items():
+                if key == "weapon":  # Ignore .weapon in base as it does not have full info.
+                    continue
+                char[key] = value
+
+            # Map properties to main/sub stat for weapon.
+            main_property = char["weapon"]["main_property"]
+            char["weapon"]["main_property"]["info"] = property_map.get(str(main_property["property_type"]), {})
+            if sub_property := char["weapon"]["sub_property"]:
+                char["weapon"]["sub_property"]["info"] = property_map.get(str(sub_property["property_type"]), {})
+
+            # Map properties to artifacts
+            for artifact in char["relics"]:
+                main_property = artifact["main_property"]
+                artifact["main_property"]["info"] = property_map.get(str(main_property["property_type"]), {})
+                for sub_property in artifact["sub_property_list"]:
+                    sub_property["info"] = property_map.get(str(sub_property["property_type"]), {})
+
+            # Map character properties
+            for prop in char['base_properties'] + char['selected_properties'] + char['extra_properties'] + char['element_properties']:
+                prop['info'] = property_map.get(str(prop['property_type']), {})
+
+        return values

--- a/genshin/models/genshin/chronicle/characters.py
+++ b/genshin/models/genshin/chronicle/characters.py
@@ -155,13 +155,11 @@ class PropertyType(APIModel):
     icon: typing.Optional[str]
     filter_name: str
 
-    @pydantic.root_validator(pre=True)
-    def __fix_names(cls, values: typing.Mapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]:
+    @pydantic.validator("name", "filter_name", pre=True)
+    @classmethod
+    def __fix_names(cls, value: str) -> str:
         r"""Fix "\xa0" in Crit Damage + Crit Rate names."""
-        name = values.get("name", "")
-        filter_name = values.get("filter_name", "")
-
-        return {**values, "name": str(name).replace("\xa0", " "), "filter_name": str(filter_name).replace("\xa0", " ")}
+        return value.replace("\xa0", " ")
 
 
 class PropertyValue(APIModel):


### PR DESCRIPTION
# About this PR
- This PR adds support for the detailed Genshin character endpoints. 

# Notes
* There are two new API endpoints that are only available on the HoYoLab app:
	* <https://bbs-api-os.hoyolab.com/game_record/app/genshin/api/character/detail>
	* <https://bbs-api-os.hoyolab.com/game_record/app/genshin/api/character/list>
	* Both of these are POST requests endpoints, and `/detail` requires a list of character_id's, which can be fetched through the `/list` endpoint. (Also how it is done on HoYoLab)
* I added a new method for this information, `get_genshin_detailed_characters`, as `get_genshin_characters`'s endpoints are still valid and return more information than just the `/list` endpoint above, so I wanted to retain it as to not break people's code whilst updating genshin.py
* All properties are mapped to their property types for ease of use. (EG: Instead of property types for artifacts all being integers, they are mapped to their actual values like "HP", "Crit Rate", etc)
* Character information is under ["base"] through the endpoint and I extracted it out to the main class, again for ease of use, and also to match with the superclass (`PartialCharacter`)
* Some internal names have been translated to work with Genshin's terms. (IE: `relic` in the requests is translated to `artifact`)

The only thing currently missing from the classes is the `recommend_relic_property` for each character. Everything else should be implemented.