### PR TITLE
Fix get_bangboos() failing Pydantic validation

### DIFF
--- a/genshin/models/zzz/chronicle/stats.py
+++ b/genshin/models/zzz/chronicle/stats.py
@@ -8,7 +8,8 @@ from genshin.models.model import Aliased, APIModel
 
 from ..character import ZZZPartialAgent
 
-__all__ = ("HIACoin", "ZZZBaseBangboo", "ZZZCatNote", "ZZZGameData", "ZZZMedal", "ZZZStats", "ZZZUserStats")
+__all__ = ("HIACoin", "ZZZBaseBangboo", "ZZZCatNote",
+           "ZZZGameData", "ZZZMedal", "ZZZStats", "ZZZUserStats")
 
 
 class HIACoin(APIModel):
@@ -79,7 +80,8 @@ class ZZZBaseBangboo(APIModel):
     rarity: typing.Literal["S", "A"]
     level: int
     star: int
-    icon: str = Aliased("bangboo_rectangle_url")
+    icon: str = pydantic.Field(validation_alias=pydantic.aliases.AliasChoices(
+        "bangboo_square_url", "bangboo_rectangle_url"))
 
 
 class ZZZUserStats(APIModel):


### PR DESCRIPTION
HoYoLAB team decided to be funny and return `bangboo_square_url` instead of `bangboo_rectangle_url` in the `api/zzz/buddy/info` route, unlike the other routes that return buddy data.