### PR TITLE
docs: update stardb.gg URLs in authentication guide

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -106,9 +106,9 @@ async for wish in client.wish_history(authkey="..."):
 
 #### PC
 
-- Genshin Impact: <https://stardb.gg/en/wish-import>
+- Genshin Impact: <https://stardb.gg/en/genshin/wish-import>
 - Honkai Star Rail: <https://stardb.gg/en/warp-import>
-- Zenless Zone Zero: <https://stardb.gg/en/signal-import>
+- Zenless Zone Zero: <https://stardb.gg/en/zzz/signal-import>
 
 Future games can also be found on the same website.
 


### PR DESCRIPTION
docs: update stardb.gg URLs in authentication guide

The older links are no longer valid and they do not even have redirects, man.

Jeez.