### PR TITLE
Feature: add credentials authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Key features:
 - Requests are significantly faster thanks to proper usage of asyncio.
 - Chinese and English names returned by the API are renamed to simpler English fields.
 - Supports the majority of the popular endpoints.
+- Simple authentication with either cookies or account credentials.
 - Cleanly integrates with frameworks like FastAPI out of the box.
 
 > Note: This library is a successor to [genshinstats](https://github.com/seriaati/genshinstats) - an unofficial wrapper for the Genshin Impact api.
@@ -58,9 +59,35 @@ pip install git+https://github.com/seriaati/genshin.py
 
 A new release is made every 2 weeks.
 
-## Example
+## Examples
 
-A very simple example of how genshin.py would be used:
+### Simple Authentication with Credentials
+
+The easiest way to authenticate is using your HoYoLAB account credentials:
+
+```py
+import asyncio
+import genshin
+
+async def main():
+    # Authenticate with email and password - no need to extract cookies!
+    client = genshin.Client(
+        credentials={
+            "account": "your_email@example.com",
+            "password": "your_password"
+        },
+        uid=710785423
+    )
+
+    user = await client.get_genshin_user()
+    print(f"User has a total of {user.stats.characters} characters")
+
+asyncio.run(main())
+```
+
+### Traditional Cookie Authentication
+
+You can still use cookies if you prefer:
 
 ```py
 import asyncio

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,5 +1,36 @@
 # Authentication
 
+genshin.py supports multiple authentication methods to suit different use cases and preferences.
+
+## Account Credentials (Recommended)
+
+The simplest way to authenticate is using your HoYoLAB account credentials (email and password). This method automatically handles cookie extraction and management, making it much more convenient than manually copying cookies from your browser.
+
+### Setting credentials
+
+```py
+# set as an __init__ parameter
+client = genshin.Client(credentials={"account": "your_email@example.com", "password": "your_password"})
+
+# or with additional parameters
+client = genshin.Client(
+    credentials={"account": "your_email@example.com", "password": "your_password"},
+    uid=123456789,
+    lang="en-us"
+)
+```
+
+**Benefits of using credentials:**
+- No need to manually extract cookies from your browser
+- Automatic cookie refreshing and management
+- Simpler setup and maintenance
+- Works with the same account you use for HoYoLAB
+
+**Important notes:**
+- Credentials are only used for initial authentication and are cleared after successful login
+- The extracted cookies are automatically formatted to work with all API endpoints
+- Cannot be used simultaneously with cookie authentication (mutually exclusive)
+
 ## Cookies
 
 Cookies are the default form of authentication over the majority of Mihoyo APIs. These are used in web events and hoyolab utilities such as the Battle Chronicle.
@@ -33,11 +64,13 @@ client.set_cookies("ltuid=...; ltoken=...") # cookie header
 4. Go to `Application`, `Cookies`, `https://www.hoyolab.com`.
 5. Copy `ltuid` and `ltoken`.
 
-#### Using username and password
+#### Using username and password (CLI)
 
 1. Run `python -m genshin login -a <account> -p <password>`.
 2. Press the `Login` button and solve a captcha.
 3. Copy cookies.
+
+**Note:** The CLI method above extracts cookies manually. For programmatic use, consider using the credentials authentication method described above instead.
 
 ### Setting cookies automatically
 
@@ -133,3 +166,17 @@ client.authkey = genshin.utility.get_authkey()
 client = genshin.Client()
 client.set_authkey()
 ```
+
+## Authentication Method Comparison
+
+| Method | Ease of Use | Security | Use Case |
+|--------|-------------|----------|----------|
+| **Credentials** | ⭐⭐⭐ Very Easy | ⭐⭐⭐ High | Recommended for most users and applications |
+| **Cookies** | ⭐⭐ Moderate | ⭐⭐ Medium | Manual control, shared accounts, specific cookie requirements |
+| **Authkey** | ⭐ Complex | ⭐⭐⭐ Very High | Read-only operations, wish history, transaction logs |
+
+**Choose credentials if:** You want the simplest setup and don't need special cookie handling.
+
+**Choose cookies if:** You need manual control over authentication, are using shared accounts, or have specific cookie requirements.
+
+**Choose authkey if:** You only need read-only access to wish history or transaction logs.

--- a/genshin/client/components/base.py
+++ b/genshin/client/components/base.py
@@ -348,12 +348,12 @@ class BaseClient(abc.ABC):
 
     async def _authenticate_with_credentials(self) -> None:
         """Authenticate using credentials if they are pending."""
-        if not hasattr(self, '_pending_credentials') or self._pending_credentials is None:
+        if not hasattr(self, "_pending_credentials") or self._pending_credentials is None:
             return
 
         credentials = self._pending_credentials
-        account = credentials.get('account')
-        password = credentials.get('password')
+        account = credentials.get("account")
+        password = credentials.get("password")
 
         if not account or not password:
             raise ValueError("Credentials must contain 'account' and 'password' keys")
@@ -364,7 +364,7 @@ class BaseClient(abc.ABC):
 
         # Perform login using the credentials
         # We need to cast self to AuthClient to access login methods
-        auth_client = typing.cast('genshin.client.components.auth.client.AuthClient', self)
+        auth_client = typing.cast("genshin.client.components.auth.client.AuthClient", self)
 
         try:
             result = await auth_client.os_login_with_password(account, password)
@@ -372,16 +372,13 @@ class BaseClient(abc.ABC):
 
             # Convert cookies to string format for parsing
             base_cookies: http.cookies.BaseCookie[str] = http.cookies.BaseCookie(completed_cookies)
-            cookie_string = base_cookies.output(header='', sep=';')
+            cookie_string = base_cookies.output(header="", sep=";")
 
             # Extract ltuid and ltoken
             auth_cookies = extract_auth_cookies(cookie_string)
 
             # Create the final cookies dict for authentication
-            final_cookies = {
-                "ltuid_v2": auth_cookies['ltuid'],
-                "ltoken_v2": auth_cookies['ltoken']
-            }
+            final_cookies = {"ltuid_v2": auth_cookies["ltuid"], "ltoken_v2": auth_cookies["ltoken"]}
 
             # Update the cookie manager with the authenticated cookies
             self.cookie_manager = managers.BaseCookieManager.from_cookies(final_cookies)

--- a/genshin/client/manager/cookie.py
+++ b/genshin/client/manager/cookie.py
@@ -261,21 +261,18 @@ def extract_auth_cookies(cookie_string: str) -> typing.Dict[str, str]:
     cookies_dict = {}
 
     # Parse cookie string into dictionary
-    for cookie_part in cookie_string.split(';'):
-        if '=' in cookie_part:
-            key, value = cookie_part.strip().split('=', 1)
+    for cookie_part in cookie_string.split(";"):
+        if "=" in cookie_part:
+            key, value = cookie_part.strip().split("=", 1)
             cookies_dict[key.strip()] = value.strip()
 
     # Extract ltuid (prioritize v2 version)
-    ltuid = cookies_dict.get('ltuid_v2') or cookies_dict.get('ltuid')
+    ltuid = cookies_dict.get("ltuid_v2") or cookies_dict.get("ltuid")
 
     # Extract ltoken (prioritize v2 version)
-    ltoken = cookies_dict.get('ltoken_v2') or cookies_dict.get('ltoken')
+    ltoken = cookies_dict.get("ltoken_v2") or cookies_dict.get("ltoken")
 
     if not ltuid or not ltoken:
         raise ValueError(f"Missing required cookies. Found: {list(cookies_dict.keys())}")
 
-    return {
-        'ltuid': ltuid,
-        'ltoken': ltoken
-    }
+    return {"ltuid": ltuid, "ltoken": ltoken}


### PR DESCRIPTION
## Summary
  Adds email/password authentication as an alternative to manual cookie extraction, making the library much more user-friendly while
  maintaining full backward compatibility.

  ## Changes
  - ✅ Added `extract_auth_cookies()` function in `genshin/client/manager/cookie.py`
  - ✅ Extended `BaseClient` constructor to accept `credentials` parameter
  - ✅ Implemented automatic authentication on first API call
  - ✅ Updated documentation with examples and comparison table
  - ✅ Maintained 100% backward compatibility

## Usage
  ```python
  # New simplified authentication
  client = genshin.Client(
      credentials={"account": "email@example.com", "password": "password"},
      uid=123456789
  )

  # Existing cookie auth still works unchanged
  client = genshin.Client(cookies={"ltuid": "123", "ltoken": "abc"}, uid=123456789)
```

##  Testing

  - ✅ Tested cookie extraction with v2 and legacy formats
  - ✅ Verified mutual exclusivity validation
  - ✅ Confirmed backward compatibility
  - ✅ Updated documentation reflects changes

##  Checklist

  - Code follows project style guidelines
  - Testing the new pushed feature was conducted and completed successfully
  - Documentation updated (readme & authentication docs)
  - Backward compatibility maintained
  - No breaking changes introduced