### PR TITLE
fix(zzz): make ShiyuDefenseV2 battle_time fields optional

### DIFF
--- a/genshin/models/zzz/chronicle/challenge/shiyu.py
+++ b/genshin/models/zzz/chronicle/challenge/shiyu.py
@@ -177,7 +177,7 @@ class ShiyuV2FifthFloorLayer(APIModel):
     buff: ShiyuDefenseBuff = Aliased("buffer")
     score: int
     max_score: int
-    clear_time: int = Aliased("battle_time")
+    clear_time: typing.Optional[int] = Aliased("battle_time", default=None)
     """Clear time in seconds."""
     boss_icon: str = Aliased("monster_pic")
     bangboo: typing.Optional[ShiyuDefenseBangboo] = Aliased("buddy", default=None)
@@ -194,7 +194,7 @@ class ShiyuV2FourthFloorLayer(APIModel):
     """ZZZ Shiyu Defense V2 fourth floor layer model."""
 
     id: int = Aliased("layer_id")
-    clear_time: int = Aliased("battle_time")
+    clear_time: typing.Optional[int] = Aliased("battle_time", default=None)
     """Clear time in seconds."""
     characters: typing.Sequence[ShiyuDefenseCharacter] = Aliased("avatar_list")
     bangboo: typing.Optional[ShiyuDefenseBangboo] = Aliased("buddy", default=None)
@@ -215,7 +215,7 @@ class ShiyuV2BriefInfo(APIModel):
     score: int
     max_score: int
     rank_percent: str
-    total_clear_time: int = Aliased("battle_time")
+    total_clear_time: typing.Optional[int] = Aliased("battle_time", default=None)
     rating: typing.Optional[typing.Literal["S+", "S", "A", "B"]]
     challenge_time: typing.Optional[DateTime] = None
 


### PR DESCRIPTION
## Summary

The HoYoLab API does not always return the `battle_time` field in `ShiyuDefenseV2` responses, causing pydantic `ValidationError` with `Field required` for:

- `brief.battle_time` (`ShiyuV2BriefInfo.total_clear_time`)
- `fourth_layer_detail.layer_challenge_info_list[n].battle_time` (`ShiyuV2FourthFloorLayer.clear_time`)
- `fitfh_layer_detail.layer_challenge_info_list[n].battle_time` (`ShiyuV2FifthFloorLayer.clear_time`)

## Fix

Made all three fields `Optional[int]` with `default=None`, consistent with how `battle_time` is already handled in `ShiyuDefenseNode` (V1):

```python
battle_time: typing.Optional[datetime.timedelta] = None
```