### PR TITLE
feat: add support for Apocalyptic Shadow Starward Mode

### DIFF
--- a/genshin/client/components/auth/server.py
+++ b/genshin/client/components/auth/server.py
@@ -26,7 +26,9 @@ from genshin.utility import auth as auth_utility
 
 __all__ = ["CAPTCHA_PAGE", "HOYOLAB_GT_SERVER", "enter_code", "launch_webapp", "solve_geetest"]
 
-CAPTCHA_PAGE: typing.Final[str] = """
+CAPTCHA_PAGE: typing.Final[
+    str
+] = """
     <!DOCTYPE html>
     <head>
       <meta name="referrer" content="no-referrer"/>

--- a/genshin/client/components/auth/server.py
+++ b/genshin/client/components/auth/server.py
@@ -26,9 +26,7 @@ from genshin.utility import auth as auth_utility
 
 __all__ = ["CAPTCHA_PAGE", "HOYOLAB_GT_SERVER", "enter_code", "launch_webapp", "solve_geetest"]
 
-CAPTCHA_PAGE: typing.Final[
-    str
-] = """
+CAPTCHA_PAGE: typing.Final[str] = """
     <!DOCTYPE html>
     <head>
       <meta name="referrer" content="no-referrer"/>

--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -183,13 +183,15 @@ class APCShadowFloor(StarRailChallengeFloor):
 
     node_1: APCShadowFloorNode
     node_2: APCShadowFloorNode
+    node_3: typing.Optional[APCShadowFloorNode] = Aliased(default=None)
     last_update_time: PartialTime
     is_quick_clear: bool = Aliased("is_fast")
+    has_starward_mode: bool = Aliased("is_tierce")
 
     @property
     def score(self) -> int:
         """Total score of the floor."""
-        return self.node_1.score + self.node_2.score
+        return self.node_1.score + self.node_2.score + (self.node_3.score if self.node_3 is not None else 0)
 
 
 class APCShadowBoss(APIModel):
@@ -205,12 +207,14 @@ class APCShadowSeason(StarRailChallengeSeason):
 
     upper_boss: APCShadowBoss
     lower_boss: APCShadowBoss
+    starward_boss: typing.Optional[APCShadowBoss] = Aliased("tierce_boss", default=None)
 
 
 class StarRailAPCShadow(APIModel):
     """Apocalyptic shadow challenge in a season."""
 
     total_stars: int = Aliased("star_num")
+    starward_star: int = Aliased("extra_star_num")
     max_floor: str
     total_battles: int = Aliased("battle_num")
     has_data: bool


### PR DESCRIPTION
Adds support for the Starward Mode (tierce) node in Apocalyptic Shadow challenge data (Fixes #377 )

## Changes

- Added `starward_star` support to StarRailAPCShadow model
- Added optional `starward_boss` support to APCShadowSeason model
- Added optional `node_3` support to APCShadowFloor model
- Updated score calculations to include node 3

## Testing

- Verified parsing of both tierce and non-tierce data