### PR TITLE
feat(starrail): add missing fields to HSR endgame challenge models

### DIFF
--- a/genshin/models/starrail/chronicle/challenge.py
+++ b/genshin/models/starrail/chronicle/challenge.py
@@ -50,6 +50,8 @@ class StarRailChallengeFloor(APIModel):
     name: str
     star_num: int
     is_quick_clear: bool = Aliased("is_fast")
+    has_starward_mode: bool = Aliased("is_tierce", default=False)
+    starward_extra_stars: int = Aliased("extra_star_num", default=0)
 
     @pydantic.computed_field  # type: ignore[prop-decorator]
     @property
@@ -63,8 +65,9 @@ class StarRailFloor(StarRailChallengeFloor):
 
     round_num: int
     is_chaos: bool
-    node_1: FloorNode
-    node_2: FloorNode
+    node_1: typing.Optional[FloorNode] = Aliased(default=None)
+    node_2: typing.Optional[FloorNode] = Aliased(default=None)
+    node_3: typing.Optional[FloorNode] = Aliased(default=None)
 
 
 class StarRailChallengeSeason(APIModel):
@@ -87,8 +90,10 @@ class StarRailChallenge(APIModel):
 
     total_stars: int = Aliased("star_num")
     max_floor: str
+    max_floor_id: int
     total_battles: int = Aliased("battle_num")
     has_data: bool
+    starward_star: int = Aliased("extra_star_num", default=0)
 
     floors: typing.Sequence[StarRailFloor] = Aliased("all_floor_detail")
     seasons: typing.Sequence[StarRailChallengeSeason] = Aliased("groups")
@@ -111,6 +116,7 @@ class ChallengeBuff(APIModel):
     id: int
     name: str = Aliased("name_mi18n")
     description: str = Aliased("desc_mi18n")
+    simple_description: typing.Optional[str] = Aliased("simple_desc_mi18m", default=None)  # only for PF
     icon: str
 
 
@@ -125,13 +131,17 @@ class FictionFloor(StarRailChallengeFloor):
     """Floor in a Pure Fiction challenge."""
 
     round_num: int
-    node_1: FictionFloorNode
-    node_2: FictionFloorNode
+    node_1: typing.Optional[FictionFloorNode] = Aliased(default=None)
+    node_2: typing.Optional[FictionFloorNode] = Aliased(default=None)
+    node_3: typing.Optional[FictionFloorNode] = Aliased(default=None)
 
     @property
     def score(self) -> int:
         """Total score of the floor."""
-        return self.node_1.score + self.node_2.score
+        node_1_score = self.node_1.score if self.node_1 is not None else 0
+        node_2_score = self.node_2.score if self.node_2 is not None else 0
+        node_3_score = self.node_3.score if self.node_3 is not None else 0
+        return node_1_score + node_2_score + node_3_score
 
 
 class StarRailPureFiction(APIModel):
@@ -146,6 +156,7 @@ class StarRailPureFiction(APIModel):
     max_floor: str
     total_battles: int = Aliased("battle_num")
     has_data: bool
+    starward_star: int = Aliased("extra_star_num", default=0)
 
     floors: list[FictionFloor] = Aliased("all_floor_detail")
     seasons: list[StarRailChallengeSeason] = Aliased("groups")
@@ -185,8 +196,6 @@ class APCShadowFloor(StarRailChallengeFloor):
     node_2: typing.Optional[APCShadowFloorNode] = Aliased(default=None)
     node_3: typing.Optional[APCShadowFloorNode] = Aliased(default=None)
     last_update_time: PartialTime
-    is_quick_clear: bool = Aliased("is_fast")
-    has_starward_mode: bool = Aliased("is_tierce", default=False)
 
     @property
     def score(self) -> int:
@@ -201,7 +210,7 @@ class APCShadowBoss(APIModel):
     """Boss in an apocalyptic shadow challenge."""
 
     id: int
-    name_mi18n: str
+    name: str = Aliased("name_mi18n")
     icon: str
 
 


### PR DESCRIPTION
- `StarRailChallengeFloor`: add `has_starward_mode` (`is_tierce`) and `starward_extra_stars` (`extra_star_num`) to the shared base class since all three game modes include these fields per-floor
- `StarRailFloor` / `FictionFloor`: add `node_3` for the starward mode third team slot; update `FictionFloor.score` to include it
- `StarRailChallenge`: add `max_floor_id` and `starward_star` (`extra_star_num`)
- `StarRailPureFiction`: add `starward_star` (`extra_star_num`)
- `ChallengeBuff`: add `simple_description` (`simple_desc_mi18m`) present in Pure Fiction buffs
- `APCShadowFloor`: remove redundant `is_quick_clear` and `has_starward_mode` overrides, now inherited from base
- `APCShadowBoss`: rename `name_mi18n` → `name` with `Aliased("name_mi18n")` for consistency

### Test plan
- [x] `ruff check` and `ruff format` pass on `challenge.py`
- [x] `nox -s test -- -k "starrail or challenge or hsr"` passes
- [x] Manually verified all four JSON response shapes (`moc.json`, `pf.json`, `apoc.json`, `aa.json`) parse correctly against the updated models